### PR TITLE
Overflowing CE (Mechamaru's) HR variant

### DIFF
--- a/src/main/java/radon/jujutsu_kaisen/ability/JJKAbilities.java
+++ b/src/main/java/radon/jujutsu_kaisen/ability/JJKAbilities.java
@@ -458,12 +458,12 @@ public class JJKAbilities {
         for (RegistryObject<Ability> entry : ABILITIES.getEntries()) {
             Ability ability = entry.get();
 
-            if (!ability.isTechnique() && (!cap.hasTrait(Trait.HEAVENLY_RESTRICTION) || ability.getCost(owner) == 0)) {
+            if (!ability.isTechnique() && (!cap.hasTrait(Trait.HEAVENLY_RESTRICTION_PHYSICAL) || ability.getCost(owner) == 0)) {
                 abilities.add(ability);
             }
         }
 
-        if (!cap.hasTrait(Trait.HEAVENLY_RESTRICTION)) {
+        if (!cap.hasTrait(Trait.HEAVENLY_RESTRICTION_PHYSICAL)) {
             for (CursedTechnique technique : cap.getTechniques()) {
                 abilities.addAll(Arrays.asList(technique.getAbilities()));
             }

--- a/src/main/java/radon/jujutsu_kaisen/ability/base/Ability.java
+++ b/src/main/java/radon/jujutsu_kaisen/ability/base/Ability.java
@@ -3,7 +3,6 @@ package radon.jujutsu_kaisen.ability.base;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.entity.Entity;
@@ -31,10 +30,6 @@ import radon.jujutsu_kaisen.util.RotationUtil;
 import net.minecraft.util.Mth;
 import radon.jujutsu_kaisen.capability.data.sorcerer.BindingVow;
 import radon.jujutsu_kaisen.capability.data.sorcerer.CursedEnergyNature;
-
-import net.minecraft.nbt.CompoundTag;
-import net.minecraft.nbt.ListTag;
-import net.minecraft.nbt.Tag;
 
 import javax.annotation.Nullable;
 
@@ -211,10 +206,13 @@ public abstract class Ability {
     public int getRealCooldown(LivingEntity owner) {
         ISorcererData cap = owner.getCapability(SorcererDataHandler.INSTANCE).resolve().orElseThrow();
 
-        if (this.isMelee() && cap.hasTrait(Trait.HEAVENLY_RESTRICTION)) {
+        if (this.isMelee() && cap.hasTrait(Trait.HEAVENLY_RESTRICTION_PHYSICAL)) {
             return this.getCooldown() / 2;
         }
-	if (this.isMelee() && cap.getNature() == CursedEnergyNature.DIVERGENT) {
+        if (this.isMelee() && cap.hasTrait(Trait.HEAVENLY_RESTRICTION_CE)) {
+            return this.getCooldown() * 2;
+        }
+        if (this.isMelee() && cap.getNature() == CursedEnergyNature.DIVERGENT) {
             return this.getCooldown() * 3 / 4;
         }
         return this.getCooldown();

--- a/src/main/java/radon/jujutsu_kaisen/ability/body_swap/BodySteal.java
+++ b/src/main/java/radon/jujutsu_kaisen/ability/body_swap/BodySteal.java
@@ -1,31 +1,17 @@
 package radon.jujutsu_kaisen.ability.body_swap;
 
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.resources.SkinManager;
-import net.minecraft.nbt.CompoundTag;
-import net.minecraft.nbt.NbtUtils;
 import net.minecraft.network.chat.Component;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.damagesource.DamageSource;
-import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.PathfinderMob;
-import net.minecraft.world.entity.TamableAnimal;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.item.ItemStack;
-import net.minecraftforge.event.entity.living.LivingDamageEvent;
 import net.minecraftforge.event.entity.living.LivingDeathEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 
-import java.util.Set;
-
 import org.jetbrains.annotations.Nullable;
-
-import com.mojang.authlib.GameProfile;
-import com.mojang.authlib.minecraft.MinecraftProfileTexture;
 
 import radon.jujutsu_kaisen.JujutsuKaisen;
 import radon.jujutsu_kaisen.ability.base.Ability;
@@ -33,18 +19,13 @@ import radon.jujutsu_kaisen.ability.JJKAbilities;
 import radon.jujutsu_kaisen.capability.data.sorcerer.ISorcererData;
 import radon.jujutsu_kaisen.capability.data.sorcerer.JujutsuType;
 import radon.jujutsu_kaisen.capability.data.sorcerer.SorcererDataHandler;
-import radon.jujutsu_kaisen.capability.data.sorcerer.AbsorbedCurse;
 import radon.jujutsu_kaisen.capability.data.sorcerer.CursedEnergyNature;
 import radon.jujutsu_kaisen.capability.data.sorcerer.CursedTechnique;
 import radon.jujutsu_kaisen.capability.data.sorcerer.Trait;
 import radon.jujutsu_kaisen.config.ConfigHolder;
-import radon.jujutsu_kaisen.item.CursedSpiritOrbItem;
-import radon.jujutsu_kaisen.item.JJKItems;
 import radon.jujutsu_kaisen.network.PacketHandler;
 import radon.jujutsu_kaisen.network.packet.s2c.SyncSorcererDataS2CPacket;
-import radon.jujutsu_kaisen.util.EntityUtil;
 import radon.jujutsu_kaisen.util.HelperMethods;
-import radon.jujutsu_kaisen.util.PlayerUtil;
 
 public class BodySteal extends Ability implements Ability.IToggled {
     @Override
@@ -160,7 +141,7 @@ public class BodySteal extends Ability implements Ability.IToggled {
                 }
             }
             for (Trait t : targetCap.getTraits()) {
-                if (t != Trait.RCT_OUTPUT && t != Trait.HEAVENLY_RESTRICTION) {
+                if (t != Trait.RCT_OUTPUT && t != Trait.HEAVENLY_RESTRICTION_PHYSICAL && t != Trait.HEAVENLY_RESTRICTION_CE) {
                     ownerCap.addTrait(t);
                 }
             }

--- a/src/main/java/radon/jujutsu_kaisen/ability/boogie_woogie/SwapSelf.java
+++ b/src/main/java/radon/jujutsu_kaisen/ability/boogie_woogie/SwapSelf.java
@@ -43,7 +43,7 @@ public class SwapSelf extends Ability {
 
     public static boolean canSwap(Entity target) {
         return (target.isPickable() || target instanceof ItemEntity item && item.getItem().getItem() instanceof CursedToolItem || target instanceof CursedEnergyImbuedItemProjectile
-                || target instanceof JujutsuProjectile) && (!(target instanceof LivingEntity living) || !JJKAbilities.hasTrait(living, Trait.HEAVENLY_RESTRICTION));
+                || target instanceof JujutsuProjectile) && (!(target instanceof LivingEntity living) || !JJKAbilities.hasTrait(living, Trait.HEAVENLY_RESTRICTION_PHYSICAL));
     }
 
     

--- a/src/main/java/radon/jujutsu_kaisen/ability/misc/Barrage.java
+++ b/src/main/java/radon/jujutsu_kaisen/ability/misc/Barrage.java
@@ -5,13 +5,10 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.InteractionHand;
-import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.PathfinderMob;
-import net.minecraft.world.entity.RiderShieldingMount;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
-import net.minecraft.world.level.Level;
 import radon.jujutsu_kaisen.ability.JJKAbilities;
 import radon.jujutsu_kaisen.capability.data.sorcerer.Trait;
 import net.minecraft.world.effect.MobEffectInstance;
@@ -19,15 +16,12 @@ import radon.jujutsu_kaisen.effect.JJKEffects;
 import net.minecraft.world.item.SwordItem;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
-import net.minecraftforge.common.ForgeMod;
 import org.jetbrains.annotations.Nullable;
 import radon.jujutsu_kaisen.ability.base.Ability;
 import radon.jujutsu_kaisen.ability.MenuType;
 import radon.jujutsu_kaisen.capability.data.sorcerer.ISorcererData;
-import radon.jujutsu_kaisen.capability.data.sorcerer.Pact;
 import radon.jujutsu_kaisen.capability.data.sorcerer.SorcererDataHandler;
 import radon.jujutsu_kaisen.entity.base.ISorcerer;
-import radon.jujutsu_kaisen.item.cursed_tool.HitenStaffItem;
 import radon.jujutsu_kaisen.item.cursed_tool.PolearmStaffItem;
 import radon.jujutsu_kaisen.item.cursed_tool.SteelGauntletItem;
 import radon.jujutsu_kaisen.item.cursed_tool.SlaughterDemonItem;
@@ -66,9 +60,12 @@ public class Barrage extends Ability {
         int gap = 2;
         ISorcererData cap = owner.getCapability(SorcererDataHandler.INSTANCE).resolve().orElseThrow();
         int duration2 = DURATION;
-        if (cap.hasTrait(Trait.HEAVENLY_RESTRICTION)) {
+        if (cap.hasTrait(Trait.HEAVENLY_RESTRICTION_PHYSICAL)) {
             duration2 = 10;
             //gap = 1;
+        }
+        if (cap.hasTrait(Trait.HEAVENLY_RESTRICTION_CE)) {
+            duration2 = 4;
         }
 
         double newRange = RANGE;
@@ -141,9 +138,9 @@ public class Barrage extends Ability {
                     if (owner.getItemInHand(InteractionHand.MAIN_HAND).getItem() instanceof SteelGauntletItem) {
                         entity.level().playSound(null, center.x, center.y, center.z, SoundEvents.ZOMBIE_ATTACK_IRON_DOOR, SoundSource.MASTER, 1.5F, 0.8F);
                     }
-
-                    entity.addEffect(new MobEffectInstance(JJKEffects.STAGGER.get(), finalStagger, 0, false, false, false));
-
+                    if (!cap.hasTrait(Trait.HEAVENLY_RESTRICTION_CE)) {
+                        entity.addEffect(new MobEffectInstance(JJKEffects.STAGGER.get(), finalStagger, 0, false, false, false));
+                    }
                     if (owner instanceof Player player) {
                         player.attack(entity);
                     } else {
@@ -167,7 +164,7 @@ public class Barrage extends Ability {
 
     @Override
     public float getCost(LivingEntity owner) {
-        return JJKAbilities.hasTrait(owner, Trait.HEAVENLY_RESTRICTION) ? 0.0F : 25.0F;
+        return JJKAbilities.hasTrait(owner, Trait.HEAVENLY_RESTRICTION_PHYSICAL) ? 0.0F : 25.0F;
     }
 
     public int getCooldown() {

--- a/src/main/java/radon/jujutsu_kaisen/ability/misc/Blitz.java
+++ b/src/main/java/radon/jujutsu_kaisen/ability/misc/Blitz.java
@@ -4,12 +4,10 @@ import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
-import net.minecraft.world.InteractionHand;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.PathfinderMob;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.item.SwordItem;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
@@ -21,7 +19,6 @@ import radon.jujutsu_kaisen.capability.data.sorcerer.ISorcererData;
 import radon.jujutsu_kaisen.capability.data.sorcerer.SorcererDataHandler;
 import radon.jujutsu_kaisen.capability.data.sorcerer.Trait;
 import radon.jujutsu_kaisen.client.particle.MirageParticle;
-import radon.jujutsu_kaisen.damage.JJKDamageSources;
 import radon.jujutsu_kaisen.effect.JJKEffects;
 import radon.jujutsu_kaisen.entity.base.ISorcerer;
 import radon.jujutsu_kaisen.sound.JJKSounds;
@@ -153,7 +150,7 @@ public class Blitz extends Ability {
     @Override
     public boolean isValid(LivingEntity owner) {
         ISorcererData cap = owner.getCapability(SorcererDataHandler.INSTANCE).resolve().orElseThrow();
-        return (!(owner instanceof ISorcerer sorcerer) || sorcerer.hasMeleeAttack() && sorcerer.hasArms()) && cap.hasTrait(Trait.HEAVENLY_RESTRICTION) && super.isValid(owner);
+        return (!(owner instanceof ISorcerer sorcerer) || sorcerer.hasMeleeAttack() && sorcerer.hasArms()) && cap.hasTrait(Trait.HEAVENLY_RESTRICTION_PHYSICAL) && super.isValid(owner);
     }
 
     @Override
@@ -163,7 +160,7 @@ public class Blitz extends Ability {
 
     @Override
     public float getCost(LivingEntity owner) {
-        return JJKAbilities.hasTrait(owner, Trait.HEAVENLY_RESTRICTION) ? 0.0F : 15.0F;
+        return JJKAbilities.hasTrait(owner, Trait.HEAVENLY_RESTRICTION_PHYSICAL) ? 0.0F : 15.0F;
     }
 
     public int getCooldown() {

--- a/src/main/java/radon/jujutsu_kaisen/ability/misc/CursedEnergyShield.java
+++ b/src/main/java/radon/jujutsu_kaisen/ability/misc/CursedEnergyShield.java
@@ -56,7 +56,7 @@ public class CursedEnergyShield extends Ability implements Ability.IChannelened 
     @Override
     public float getCost(LivingEntity owner) {
         ISorcererData cap = owner.getCapability(SorcererDataHandler.INSTANCE).resolve().orElseThrow();
-        if (cap.hasTrait(Trait.HEAVENLY_RESTRICTION)) {
+        if (cap.hasTrait(Trait.HEAVENLY_RESTRICTION_PHYSICAL)) {
             return 0.0F;
         }
         return 2.0F ;

--- a/src/main/java/radon/jujutsu_kaisen/ability/misc/Dash.java
+++ b/src/main/java/radon/jujutsu_kaisen/ability/misc/Dash.java
@@ -9,17 +9,11 @@ import net.minecraft.sounds.SoundSource;
 import net.minecraft.util.Mth;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.entity.LivingEntity;
-import net.minecraft.world.entity.MoverType;
 import net.minecraft.world.entity.PathfinderMob;
-import net.minecraft.world.level.BlockGetter;
-import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
-import net.minecraft.world.phys.shapes.BooleanOp;
-import net.minecraft.world.phys.shapes.Shapes;
-import net.minecraft.world.phys.shapes.VoxelShape;
 import org.jetbrains.annotations.Nullable;
 import radon.jujutsu_kaisen.ability.JJKAbilities;
 import radon.jujutsu_kaisen.ability.MenuType;
@@ -58,7 +52,7 @@ public class Dash extends Ability {
     public boolean shouldTrigger(PathfinderMob owner, @Nullable LivingEntity target) {
         if (target == null) return false;
         ISorcererData cap = owner.getCapability(SorcererDataHandler.INSTANCE).resolve().orElseThrow();
-        if (cap.hasTrait(Trait.HEAVENLY_RESTRICTION)) {
+        if (cap.hasTrait(Trait.HEAVENLY_RESTRICTION_PHYSICAL)) {
             return HelperMethods.RANDOM.nextInt(2) == 0;
         }
         return HelperMethods.RANDOM.nextInt(15) == 0;
@@ -131,7 +125,10 @@ public class Dash extends Ability {
     }
 
     private static float getRange(LivingEntity owner) {
-        return (float) (RANGE * (JJKAbilities.hasTrait(owner, Trait.HEAVENLY_RESTRICTION) ? 1.5F : 1.0F));
+        float modifier = 1.0F;
+        if (JJKAbilities.hasTrait(owner, Trait.HEAVENLY_RESTRICTION_PHYSICAL)) modifier = 1.5F;
+        if (JJKAbilities.hasTrait(owner, Trait.HEAVENLY_RESTRICTION_CE)) modifier = 0.5F;
+        return (float) (RANGE * modifier);
     }
 
    private Vec3 getTarget(LivingEntity owner) {
@@ -156,7 +153,7 @@ public class Dash extends Ability {
 
         owner.level().playSound(null, owner.getX(), owner.getY(), owner.getZ(), SoundEvents.BUNDLE_INSERT, SoundSource.MASTER, 2F, 1.25F);
 
-        if (cap.getSpeedStacks() > 0 || cap.hasTrait(Trait.HEAVENLY_RESTRICTION)) {
+        if (cap.getSpeedStacks() > 0 || cap.hasTrait(Trait.HEAVENLY_RESTRICTION_PHYSICAL)) {
             owner.level().playSound(null, owner.getX(), owner.getY(), owner.getZ(), JJKSounds.DASH.get(), SoundSource.MASTER, 0.2F, 1.5F);
             owner.addEffect(new MobEffectInstance(JJKEffects.INVISIBILITY.get(), 4, 0, false, false, false));
             level.sendParticles(new MirageParticle.MirageParticleOptions(owner.getId()), owner.getX(), owner.getY(), owner.getZ(),
@@ -189,7 +186,7 @@ public class Dash extends Ability {
         } else {
             velocity = velocity.multiply(new Vec3(1.2D,1.3,1.2D));
         }
-        if (cap.hasTrait(Trait.HEAVENLY_RESTRICTION)) {
+        if (cap.hasTrait(Trait.HEAVENLY_RESTRICTION_PHYSICAL)) {
             velocity = velocity.multiply(new Vec3(1.2D, 1.0D, 1.2D));
             if (!owner.isShiftKeyDown()) {
                 owner.addEffect(new MobEffectInstance(JJKEffects.INVISIBILITY.get(), 8, 0, false, false, false));
@@ -198,6 +195,9 @@ public class Dash extends Ability {
                 owner.addEffect(new MobEffectInstance(JJKEffects.INVISIBILITY.get(), 4, 0, false, false, false));
                 velocity = velocity.multiply(new Vec3(1.1D, 1, 1.1D));
             }
+        }
+        if (cap.hasTrait(Trait.HEAVENLY_RESTRICTION_CE)) {
+            velocity = velocity.multiply(new Vec3(0.8D, 1.0D, 0.8D));
         }
         if (owner.onGround() && velocity.y < 0) {
             velocity.multiply(1,0,1);
@@ -283,11 +283,17 @@ public class Dash extends Ability {
     public int getRealCooldown(LivingEntity owner) {
         ISorcererData cap = owner.getCapability(SorcererDataHandler.INSTANCE).resolve().orElseThrow();
 
-        if (cap.hasTrait(Trait.HEAVENLY_RESTRICTION)) {
+        if (cap.hasTrait(Trait.HEAVENLY_RESTRICTION_PHYSICAL)) {
             if (!owner.isShiftKeyDown()) {
                 return 16;
             }
             return 8;
+        }
+        if (cap.hasTrait(Trait.HEAVENLY_RESTRICTION_CE)) {
+            if (!owner.isShiftKeyDown()) {
+                return 50;
+            }
+            return 25;
         }
         if (!owner.isShiftKeyDown()) {
             return 25;

--- a/src/main/java/radon/jujutsu_kaisen/ability/misc/Punch.java
+++ b/src/main/java/radon/jujutsu_kaisen/ability/misc/Punch.java
@@ -7,16 +7,13 @@ import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.effect.MobEffectInstance;
-import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.PathfinderMob;
-import net.minecraft.world.entity.RiderShieldingMount;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.SwordItem;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.AABB;
-import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
 import org.jetbrains.annotations.Nullable;
 import radon.jujutsu_kaisen.JujutsuKaisen;
@@ -24,15 +21,12 @@ import radon.jujutsu_kaisen.ability.JJKAbilities;
 import radon.jujutsu_kaisen.ability.MenuType;
 import radon.jujutsu_kaisen.ability.base.Ability;
 import radon.jujutsu_kaisen.capability.data.sorcerer.ISorcererData;
-import radon.jujutsu_kaisen.capability.data.sorcerer.Pact;
 import radon.jujutsu_kaisen.capability.data.sorcerer.SorcererDataHandler;
 import radon.jujutsu_kaisen.capability.data.sorcerer.Trait;
 import radon.jujutsu_kaisen.client.ClientWrapper;
 import radon.jujutsu_kaisen.damage.JJKDamageSources;
 import radon.jujutsu_kaisen.effect.JJKEffects;
 import radon.jujutsu_kaisen.entity.base.ISorcerer;
-import radon.jujutsu_kaisen.item.cursed_tool.HitenStaffItem;
-import radon.jujutsu_kaisen.item.cursed_tool.PlayfulCloudItem;
 import radon.jujutsu_kaisen.item.cursed_tool.PolearmStaffItem;
 import radon.jujutsu_kaisen.item.cursed_tool.SteelGauntletItem;
 import radon.jujutsu_kaisen.item.cursed_tool.SlaughterDemonItem;
@@ -174,7 +168,7 @@ public class Punch extends Ability implements Ability.ICharged{
                         int tim = 8;
 
                         if (power == 1) {
-                            if (!cap.hasToggled(JJKAbilities.RATIO_RULE.get()) && (!JJKAbilities.hasTrait(owner, Trait.HEAVENLY_RESTRICTION))) {
+                            if (!cap.hasToggled(JJKAbilities.RATIO_RULE.get()) && (!JJKAbilities.hasTrait(owner, Trait.HEAVENLY_RESTRICTION_PHYSICAL))) {
                                 cap.moreBlackFlash(true);
                             }
 
@@ -220,16 +214,22 @@ public class Punch extends Ability implements Ability.ICharged{
                     float newPower = (float) (LAUNCH_POWER*(0.8+0.4*power));
                     newDMG *= (float) (1+0.75 *power);
                     
-                    if (JJKAbilities.hasTrait(owner, Trait.HEAVENLY_RESTRICTION)) {
+                    if (JJKAbilities.hasTrait(owner, Trait.HEAVENLY_RESTRICTION_PHYSICAL)) {
                         if (entity.hurt(owner instanceof Player player ? owner.damageSources().playerAttack(player) : owner.damageSources().mobAttack(owner), (newDMG * 1.25F) * this.getPower(owner))) {
                             entity.setDeltaMovement(look.scale(newPower * (1.0F + this.getPower(owner) * 0.1F) * 1.5F)
                                     .multiply(1.0D, 0.25D, 1.0D));
                             entity.addEffect(new MobEffectInstance(JJKEffects.STUN.get(), tim, 0, false, false, false));
                             entity.addEffect(new MobEffectInstance(JJKEffects.STAGGER.get(), finalStagger, 0, false, false, false));
                         }
-                    }
-
-                    else {
+                    } else if (JJKAbilities.hasTrait(owner, Trait.HEAVENLY_RESTRICTION_CE))
+                        {
+                        if (entity.hurt(owner instanceof Player player ? owner.damageSources().playerAttack(player) : owner.damageSources().mobAttack(owner), (newDMG * 0.5F) * this.getPower(owner))) {
+                            entity.setDeltaMovement(look.scale(newPower * (1.0F + this.getPower(owner) * 0.1F) * 0.5F)
+                                    .multiply(0.8D, 0.25D, 0.8D));
+                            //entity.addEffect(new MobEffectInstance(JJKEffects.STUN.get(), tim, 0, false, false, false));
+                            //entity.addEffect(new MobEffectInstance(JJKEffects.STAGGER.get(), finalStagger, 0, false, false, false));
+                        }
+                        } else {
                         if (entity.hurt(JJKDamageSources.jujutsuAttack(owner, this), (newDMG) * this.getPower(owner))) {
                             if (owner instanceof Player player) {
                                 entity.setDeltaMovement(look.scale(newPower * (1.0F + this.getPower(owner) * 0.1F))
@@ -241,8 +241,7 @@ public class Punch extends Ability implements Ability.ICharged{
                             }
                             entity.addEffect(new MobEffectInstance(JJKEffects.STUN.get(), tim, 0, false, false, false));
                             entity.addEffect(new MobEffectInstance(JJKEffects.STAGGER.get(), finalStagger, 0, false, false, false));
-
-                    }
+                        }
                     }
 
                     }
@@ -296,7 +295,7 @@ public class Punch extends Ability implements Ability.ICharged{
 
     @Override
     public float getCost(LivingEntity owner) {
-        return JJKAbilities.hasTrait(owner, Trait.HEAVENLY_RESTRICTION) ? 0.0F : 20.0F;
+        return JJKAbilities.hasTrait(owner, Trait.HEAVENLY_RESTRICTION_PHYSICAL) ? 0.0F : 20.0F;
     }
 
     @Override

--- a/src/main/java/radon/jujutsu_kaisen/ability/misc/QuickDash.java
+++ b/src/main/java/radon/jujutsu_kaisen/ability/misc/QuickDash.java
@@ -9,28 +9,19 @@ import net.minecraft.sounds.SoundSource;
 import net.minecraft.util.Mth;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.entity.LivingEntity;
-import net.minecraft.world.entity.MoverType;
 import net.minecraft.world.entity.PathfinderMob;
-import net.minecraft.world.level.BlockGetter;
-import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
-import net.minecraft.world.phys.shapes.BooleanOp;
-import net.minecraft.world.phys.shapes.Shapes;
-import net.minecraft.world.phys.shapes.VoxelShape;
 
 import org.jetbrains.annotations.Nullable;
 import radon.jujutsu_kaisen.ability.JJKAbilities;
-import radon.jujutsu_kaisen.ability.MenuType;
-import radon.jujutsu_kaisen.ability.base.Ability;
 import radon.jujutsu_kaisen.capability.data.sorcerer.ISorcererData;
 import radon.jujutsu_kaisen.capability.data.sorcerer.SorcererDataHandler;
 import radon.jujutsu_kaisen.capability.data.sorcerer.Trait;
 import radon.jujutsu_kaisen.client.particle.MirageParticle;
 import radon.jujutsu_kaisen.effect.JJKEffects;
-import radon.jujutsu_kaisen.entity.base.ISorcerer;
 import radon.jujutsu_kaisen.sound.JJKSounds;
 import radon.jujutsu_kaisen.util.HelperMethods;
 import radon.jujutsu_kaisen.util.RotationUtil;
@@ -45,7 +36,7 @@ public class QuickDash extends Dash {
         if (target == null) return false;
         ISorcererData cap = owner.getCapability(SorcererDataHandler.INSTANCE).resolve().orElseThrow();
 
-        if (cap.hasTrait(Trait.HEAVENLY_RESTRICTION)) {
+        if (cap.hasTrait(Trait.HEAVENLY_RESTRICTION_PHYSICAL)) {
             return HelperMethods.RANDOM.nextInt(1) == 0;
         }
 
@@ -77,7 +68,10 @@ public class QuickDash extends Dash {
         
 
     private static float getRange(LivingEntity owner) {
-        return (float) (RANGE * (JJKAbilities.hasTrait(owner, Trait.HEAVENLY_RESTRICTION) ? 1.5F : 1.0F));
+        float modifier = 1.0F;
+        if (JJKAbilities.hasTrait(owner, Trait.HEAVENLY_RESTRICTION_PHYSICAL)) modifier = 1.5F;
+        if (JJKAbilities.hasTrait(owner, Trait.HEAVENLY_RESTRICTION_CE)) modifier = 0.5F;
+        return (float) (RANGE * modifier);
     }
 
     private static boolean canDash(LivingEntity owner) {
@@ -128,7 +122,7 @@ public class QuickDash extends Dash {
 
         owner.level().playSound(null, owner.getX(), owner.getY(), owner.getZ(), SoundEvents.BUNDLE_INSERT, SoundSource.MASTER, 2F, 1.25F);
 
-        if (cap.getSpeedStacks() > 0 || cap.hasTrait(Trait.HEAVENLY_RESTRICTION)) {
+        if (cap.getSpeedStacks() > 0 || cap.hasTrait(Trait.HEAVENLY_RESTRICTION_PHYSICAL)) {
             owner.level().playSound(null, owner.getX(), owner.getY(), owner.getZ(), JJKSounds.DASH.get(), SoundSource.MASTER, 0.2F, 1.5F);
             owner.addEffect(new MobEffectInstance(JJKEffects.INVISIBILITY.get(), 4, 0, false, false, false));
             level.sendParticles(new MirageParticle.MirageParticleOptions(owner.getId()), owner.getX(), owner.getY(), owner.getZ(),
@@ -158,7 +152,7 @@ public class QuickDash extends Dash {
         } else {
             velocity = velocity.multiply(new Vec3(1.2D,1.3,1.2D));
         }
-        if (cap.hasTrait(Trait.HEAVENLY_RESTRICTION)) {
+        if (cap.hasTrait(Trait.HEAVENLY_RESTRICTION_PHYSICAL)) {
             velocity = velocity.multiply(new Vec3(1.2D, 1.0D, 1.2D));
             if (owner.isShiftKeyDown()) {
                 owner.addEffect(new MobEffectInstance(JJKEffects.INVISIBILITY.get(), 8, 0, false, false, false));
@@ -168,6 +162,9 @@ public class QuickDash extends Dash {
                 velocity = velocity.multiply(new Vec3(1.1D, 1, 1.1D));
             }
            
+        }
+        if (cap.hasTrait(Trait.HEAVENLY_RESTRICTION_CE)) {
+            velocity = velocity.multiply(new Vec3(0.8D, 1.0D, 0.8D));
         }
         if (owner.onGround() && velocity.y < 0) {
             velocity.multiply(1,0,1);
@@ -237,11 +234,17 @@ public class QuickDash extends Dash {
     @Override
     public int getRealCooldown(LivingEntity owner) {
         ISorcererData cap = owner.getCapability(SorcererDataHandler.INSTANCE).resolve().orElseThrow();
-        if (cap.hasTrait(Trait.HEAVENLY_RESTRICTION)) {
+        if (cap.hasTrait(Trait.HEAVENLY_RESTRICTION_PHYSICAL)) {
             if (owner.isShiftKeyDown()) {
                 return 16;
             }
             return 8;
+        }
+        if (cap.hasTrait(Trait.HEAVENLY_RESTRICTION_CE)) {
+            if (!owner.isShiftKeyDown()) {
+                return 50;
+            }
+            return 25;
         }
         if (owner.isShiftKeyDown()) {
             return 25;

--- a/src/main/java/radon/jujutsu_kaisen/ability/misc/Slam.java
+++ b/src/main/java/radon/jujutsu_kaisen/ability/misc/Slam.java
@@ -24,7 +24,6 @@ import radon.jujutsu_kaisen.capability.data.sorcerer.Trait;
 import radon.jujutsu_kaisen.client.ClientWrapper;
 import radon.jujutsu_kaisen.effect.JJKEffects;
 import radon.jujutsu_kaisen.entity.base.ISorcerer;
-import radon.jujutsu_kaisen.ability.JJKAbilities;
 import radon.jujutsu_kaisen.entity.ten_shadows.RabbitEscapeEntity;
 import radon.jujutsu_kaisen.item.cursed_tool.SteelGauntletItem;
 import radon.jujutsu_kaisen.item.cursed_tool.SlaughterDemonItem;
@@ -86,7 +85,7 @@ public class Slam extends Ability implements Ability.ICharged {
 
     @Override
     public float getCost(LivingEntity owner) {
-        return JJKAbilities.hasTrait(owner, Trait.HEAVENLY_RESTRICTION) ? 0.0F : 30.0F;
+        return JJKAbilities.hasTrait(owner, Trait.HEAVENLY_RESTRICTION_PHYSICAL) ? 0.0F : 30.0F;
     }
 
     public int getCooldown() {
@@ -122,9 +121,13 @@ public class Slam extends Ability implements Ability.ICharged {
         
         float radius = MAX_EXPLOSION;
         float dmgMult = 0.75F;
-        if (JJKAbilities.hasTrait(owner, Trait.HEAVENLY_RESTRICTION)) {
+        if (JJKAbilities.hasTrait(owner, Trait.HEAVENLY_RESTRICTION_PHYSICAL)) {
             dmgMult = 0.8F;
             radius = radius*1.35f+1.5f;
+        }
+        if (JJKAbilities.hasTrait(owner, Trait.HEAVENLY_RESTRICTION_CE)) {
+            dmgMult = 0.65F;
+            radius = radius*0.65f-1.5f;
         }
         if (owner instanceof RabbitEscapeEntity) {
             radius = 1f;
@@ -164,9 +167,13 @@ public class Slam extends Ability implements Ability.ICharged {
                 if (owner.getItemInHand(InteractionHand.MAIN_HAND).getItem() instanceof SlaughterDemonItem) {
                     staggerDuration = 20;
                 }
-
-                entity.addEffect(new MobEffectInstance(JJKEffects.STUN.get(),stunDuration, 0, false, false, false));
-                entity.addEffect(new MobEffectInstance(JJKEffects.STAGGER.get(),staggerDuration, 0, false, false, false));
+                if (owner.getCapability(SorcererDataHandler.INSTANCE).isPresent()) {
+                    ISorcererData cap = owner.getCapability(SorcererDataHandler.INSTANCE).resolve().orElseThrow();
+                    if (cap.hasTrait(Trait.HEAVENLY_RESTRICTION_CE)) {
+                        entity.addEffect(new MobEffectInstance(JJKEffects.STUN.get(), stunDuration, 0, false, false, false));
+                        entity.addEffect(new MobEffectInstance(JJKEffects.STAGGER.get(), staggerDuration, 0, false, false, false));
+                    }
+                }
             }
              ExplosionHandler.spawn(owner.level().dimension(), owner.position(), radius, 5, Ability.getPower(JJKAbilities.SLAM.get(), owner) * dmgMult, owner,
                     owner instanceof Player player ? owner.damageSources().playerAttack(player) : owner.damageSources().mobAttack(owner), false, true );
@@ -188,6 +195,12 @@ public class Slam extends Ability implements Ability.ICharged {
        
 
         double launchPower = 2.0D + (2.0D * (Math.min(20, this.getCharge(owner)) / 20));
+        if (owner.getCapability(SorcererDataHandler.INSTANCE).isPresent()) {
+            ISorcererData cap = owner.getCapability(SorcererDataHandler.INSTANCE).resolve().orElseThrow();
+            if (cap.hasTrait(Trait.HEAVENLY_RESTRICTION_CE)){
+                launchPower /= 2D;
+            }
+        }
         float checkcharge = (float) Math.min(20, this.getCharge(owner)) / 20;
 
         ISorcererData cap = owner.getCapability(SorcererDataHandler.INSTANCE).resolve().orElseThrow();

--- a/src/main/java/radon/jujutsu_kaisen/ability/misc/TestDash.java
+++ b/src/main/java/radon/jujutsu_kaisen/ability/misc/TestDash.java
@@ -95,7 +95,7 @@ public class TestDash extends Ability {
     }
 
     private static float getRange(LivingEntity owner) {
-        return (float) (RANGE * (JJKAbilities.hasTrait(owner, Trait.HEAVENLY_RESTRICTION) ? 1.5F : 1.0F));
+        return (float) (RANGE * (JJKAbilities.hasTrait(owner, Trait.HEAVENLY_RESTRICTION_PHYSICAL) ? 1.5F : 1.0F));
     }
 
    private Vec3 getTarget(LivingEntity owner) {
@@ -144,7 +144,7 @@ public class TestDash extends Ability {
 
         ISorcererData cap = owner.getCapability(SorcererDataHandler.INSTANCE).resolve().orElseThrow();
 
-        if (cap.getSpeedStacks() > 0 || cap.hasTrait(Trait.HEAVENLY_RESTRICTION)) {
+        if (cap.getSpeedStacks() > 0 || cap.hasTrait(Trait.HEAVENLY_RESTRICTION_PHYSICAL)) {
             owner.level().playSound(null, owner.getX(), owner.getY(), owner.getZ(), JJKSounds.DASH.get(), SoundSource.MASTER, 1.0F, 1.0F);
             owner.addEffect(new MobEffectInstance(JJKEffects.INVISIBILITY.get(), 5, 0, false, false, false));
             level.sendParticles(new MirageParticle.MirageParticleOptions(owner.getId()), owner.getX(), owner.getY(), owner.getZ(),
@@ -161,7 +161,7 @@ public class TestDash extends Ability {
         Vec3 look = target;
 
         velocity = velocity.multiply(new Vec3(0.7D, 1.0D, 0.7D));
-        if (cap.hasTrait(Trait.HEAVENLY_RESTRICTION)) {
+        if (cap.hasTrait(Trait.HEAVENLY_RESTRICTION_PHYSICAL)) {
             velocity = velocity.multiply(new Vec3(1.2D, 1D, 1.2)).add(new Vec3(0.0D, 0.05D,0.0D));
         }
         velocity = velocity.add(new Vec3(0.0D,0.2D,0.0D));
@@ -208,7 +208,7 @@ public class TestDash extends Ability {
     public int getRealCooldown(LivingEntity owner) {
         ISorcererData cap = owner.getCapability(SorcererDataHandler.INSTANCE).resolve().orElseThrow();
 
-        if (cap.hasTrait(Trait.HEAVENLY_RESTRICTION)) {
+        if (cap.hasTrait(Trait.HEAVENLY_RESTRICTION_PHYSICAL)) {
             return 4;
         }
         return super.getRealCooldown(owner);

--- a/src/main/java/radon/jujutsu_kaisen/ability/misc/ZeroPointTwoSecondDomainExpansion.java
+++ b/src/main/java/radon/jujutsu_kaisen/ability/misc/ZeroPointTwoSecondDomainExpansion.java
@@ -1,8 +1,6 @@
 package radon.jujutsu_kaisen.ability.misc;
 
-import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.sounds.SoundSource;
-import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.PathfinderMob;
 import net.minecraft.world.entity.player.Player;
@@ -18,8 +16,6 @@ import radon.jujutsu_kaisen.capability.data.sorcerer.SorcererDataHandler;
 import radon.jujutsu_kaisen.capability.data.sorcerer.CursedTechnique;
 import radon.jujutsu_kaisen.config.ConfigHolder;
 import radon.jujutsu_kaisen.entity.base.DomainExpansionEntity;
-import radon.jujutsu_kaisen.network.PacketHandler;
-import radon.jujutsu_kaisen.network.packet.s2c.SyncSorcererDataS2CPacket;
 import radon.jujutsu_kaisen.sound.JJKSounds;
 import radon.jujutsu_kaisen.capability.data.sorcerer.Trait;
 
@@ -103,7 +99,7 @@ public class ZeroPointTwoSecondDomainExpansion extends Ability {
             domain.setInstant(true);
             cap.delayTickEvent(() -> {
                 for (LivingEntity entity : domain.getAffected()) {
-                    if (JJKAbilities.hasTrait(entity, Trait.HEAVENLY_RESTRICTION)) {
+                    if (JJKAbilities.hasTrait(entity, Trait.HEAVENLY_RESTRICTION_PHYSICAL)) {
                         ability.onHitBlock(domain, owner, entity.blockPosition());
                     } else {
                         ability.onHitEntity(domain, owner, entity, true);

--- a/src/main/java/radon/jujutsu_kaisen/block/VeilBlock.java
+++ b/src/main/java/radon/jujutsu_kaisen/block/VeilBlock.java
@@ -6,13 +6,10 @@ import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.projectile.Projectile;
 import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.level.BlockGetter;
-import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.RenderShape;
 import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraft.world.level.block.entity.BlockEntityTicker;
-import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
@@ -60,7 +57,7 @@ public class VeilBlock extends Block implements EntityBlock {
             Entity entity = ctx.getEntity();
 
             if (entity != null) {
-                if (entity instanceof LivingEntity living && (JJKAbilities.hasTrait(living, Trait.HEAVENLY_RESTRICTION) || JJKAbilities.hasToggled(living, JJKAbilities.BARRIER_TRAVEL.get()) ) && !pContext.isAbove(Shapes.block(), pPos, true)) {
+                if (entity instanceof LivingEntity living && (JJKAbilities.hasTrait(living, Trait.HEAVENLY_RESTRICTION_PHYSICAL) || JJKAbilities.hasToggled(living, JJKAbilities.BARRIER_TRAVEL.get()) ) && !pContext.isAbove(Shapes.block(), pPos, true)) {
                     return Shapes.empty();
                 }
                 if (entity instanceof Projectile projectile) entity = projectile.getOwner();

--- a/src/main/java/radon/jujutsu_kaisen/block/domain/DomainBlock.java
+++ b/src/main/java/radon/jujutsu_kaisen/block/domain/DomainBlock.java
@@ -6,7 +6,6 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Explosion;
-import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.EntityBlock;
@@ -21,7 +20,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import radon.jujutsu_kaisen.ability.JJKAbilities;
-import radon.jujutsu_kaisen.block.JJKBlocks;
 import radon.jujutsu_kaisen.block.entity.DomainBlockEntity;
 import radon.jujutsu_kaisen.block.entity.JJKBlockEntities;
 import radon.jujutsu_kaisen.capability.data.sorcerer.ISorcererData;
@@ -46,7 +44,7 @@ public class DomainBlock extends Block implements EntityBlock {
                 if (entity.getCapability(SorcererDataHandler.INSTANCE).isPresent()) {
                     ISorcererData cap = entity.getCapability(SorcererDataHandler.INSTANCE).resolve().orElseThrow();
 
-                    if (cap.hasTrait(Trait.HEAVENLY_RESTRICTION) || (entity instanceof LivingEntity living && (JJKAbilities.hasToggled(living, JJKAbilities.BARRIER_TRAVEL.get()))) ) {
+                    if (cap.hasTrait(Trait.HEAVENLY_RESTRICTION_PHYSICAL) || (entity instanceof LivingEntity living && (JJKAbilities.hasToggled(living, JJKAbilities.BARRIER_TRAVEL.get()))) ) {
                         if (!pContext.isAbove(Shapes.block(), pPos, true)) {
                             return Shapes.empty();
                         }

--- a/src/main/java/radon/jujutsu_kaisen/capability/data/sorcerer/SorcererData.java
+++ b/src/main/java/radon/jujutsu_kaisen/capability/data/sorcerer/SorcererData.java
@@ -2,7 +2,6 @@ package radon.jujutsu_kaisen.capability.data.sorcerer;
 
 import com.mojang.authlib.GameProfile;
 
-import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.nbt.*;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
@@ -14,21 +13,16 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.players.GameProfileCache;
 import net.minecraft.world.damagesource.DamageSource;
-import net.minecraft.world.damagesource.DamageType;
-import net.minecraft.world.damagesource.DamageTypes;
-import net.minecraft.world.effect.MobEffectInstance;   
+import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.entity.*;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.level.Level;
 import net.minecraft.world.level.entity.EntityTypeTest;
 import net.minecraft.world.phys.Vec3;
-import net.minecraftforge.common.ForgeConfigSpec;
 import net.minecraftforge.common.ForgeMod;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.network.PacketDistributor;
 import net.minecraftforge.server.ServerLifecycleHooks;
 import radon.jujutsu_kaisen.JJKConstants;
 import radon.jujutsu_kaisen.JujutsuKaisen;
@@ -39,12 +33,8 @@ import radon.jujutsu_kaisen.ability.misc.Slam;
 import radon.jujutsu_kaisen.client.particle.ParticleColors;
 import radon.jujutsu_kaisen.client.visual.ClientVisualHandler;
 import radon.jujutsu_kaisen.config.ConfigHolder;
-import radon.jujutsu_kaisen.config.ServerConfig;
-import radon.jujutsu_kaisen.entity.base.ISorcerer;
 import radon.jujutsu_kaisen.network.PacketHandler;
 import radon.jujutsu_kaisen.item.JJKItems;
-import radon.jujutsu_kaisen.item.cursed_tool.HitenStaffItem;
-import radon.jujutsu_kaisen.network.packet.c2s.UncopyAbilityC2SPacket;
 import radon.jujutsu_kaisen.network.packet.c2s.UnstealAbilityC2SPacket;
 import radon.jujutsu_kaisen.network.packet.s2c.SyncSorcererDataS2CPacket;
 import radon.jujutsu_kaisen.network.packet.s2c.SyncVisualDataS2CPacket;
@@ -53,8 +43,6 @@ import radon.jujutsu_kaisen.util.EntityUtil;
 import radon.jujutsu_kaisen.util.HelperMethods;
 import radon.jujutsu_kaisen.util.PlayerUtil;
 import radon.jujutsu_kaisen.util.SorcererUtil;
-import virtuoel.pehkui.api.ScaleData;
-import virtuoel.pehkui.api.ScaleTypes;
 
 import javax.annotation.Nullable;
 import java.util.*;
@@ -153,6 +141,9 @@ public class SorcererData implements ISorcererData {
     private static final UUID ATTACK_DAMAGE_UUID = UUID.fromString("4979087e-da76-4f8a-93ef-6e5847bfa2ee");
     private static final UUID ATTACK_SPEED_UUID = UUID.fromString("a2aef906-ed31-49e8-a56c-decccbfa2c1f");
     private static final UUID MOVEMENT_SPEED_UUID = UUID.fromString("9fe023ca-f22b-4429-a5e5-c099387d5441");
+    private static final UUID STEP_HEIGHT_UUID = UUID.fromString("654c65b5-dc0f-4092-8423-59cbe3d19682");
+    private static final UUID ARMOR_UUID = UUID.fromString("486fd273-fdbc-4876-b0b8-af5a64bfb08a");
+    private static final UUID ARMOR_TOUGHNESS_UUID = UUID.fromString("0be71dde-8aeb-4c5d-955f-d37325c31a94");
     private static final UUID PROJECTION_SORCERY_MOVEMENT_SPEED_UUID = UUID.fromString("23ecaba3-fbe8-44c1-93c4-5291aa9ee777");
     private static final UUID PROJECTION_ATTACK_SPEED_UUID = UUID.fromString("18cd1e25-656d-4172-b9f7-2f1b3daf4b89");
     private static final UUID PROJECTION_STEP_HEIGHT_UUID = UUID.fromString("1dbcbef7-8193-406a-b64d-8766ea505fdb");
@@ -388,7 +379,8 @@ public class SorcererData implements ISorcererData {
 
     private void checkAdvancements(ServerPlayer player) {
         if (this.traits.contains(Trait.SIX_EYES)) PlayerUtil.giveAdvancement(player, "six_eyes");
-        if (this.traits.contains(Trait.HEAVENLY_RESTRICTION)) PlayerUtil.giveAdvancement(player, "heavenly_restriction");
+        if (this.traits.contains(Trait.HEAVENLY_RESTRICTION_PHYSICAL)) PlayerUtil.giveAdvancement(player, "heavenly_restriction_physical");
+        if (this.traits.contains(Trait.HEAVENLY_RESTRICTION_CE)) PlayerUtil.giveAdvancement(player, "heavenly_restriction_ce");
         if (this.traits.contains(Trait.VESSEL)) PlayerUtil.giveAdvancement(player, "vessel");
         if (this.unlocked.contains(JJKAbilities.RCT1.get()))
             PlayerUtil.giveAdvancement(player, "reverse_cursed_technique");
@@ -511,13 +503,15 @@ public class SorcererData implements ISorcererData {
             this.silenced--;
         }
 
-        this.energy = Math.min(this.energy + (ConfigHolder.SERVER.cursedEnergyRegenerationAmount.get().floatValue() * ((this.owner instanceof Player player && ConfigHolder.SERVER.foodCERegen.get()) ? (player.getFoodData().getFoodLevel() / 20.0F) : 1.0F)), this.getMaxEnergy());
+        this.energy = Math.min(this.energy + (ConfigHolder.SERVER.cursedEnergyRegenerationAmount.get().floatValue()
+                * (traits.contains(Trait.HEAVENLY_RESTRICTION_CE) ? ConfigHolder.SERVER.cehrCEMult.get().floatValue() : 1.0F)
+                * ((this.owner instanceof Player player && ConfigHolder.SERVER.foodCERegen.get()) ? (player.getFoodData().getFoodLevel() / 20.0F) : 1.0F)
+                ), this.getMaxEnergy());
 
-        if (this.traits.contains(Trait.HEAVENLY_RESTRICTION)) {
-            double health = (Math.ceil(((this.getRealPower() - 1.0F) * ConfigHolder.SERVER.npcHPMult.get().floatValue() ) / 20) * 20) + ConfigHolder.SERVER.npcHPMin.get();
-
+        double health = (Math.ceil(((this.getRealPower() - 1.0F) * ConfigHolder.SERVER.npcHPMult.get().floatValue() ) / 20) * 20) + ConfigHolder.SERVER.npcHPMin.get();
+        if (this.traits.contains(Trait.HEAVENLY_RESTRICTION_PHYSICAL)) {
             if (this.owner instanceof Player player) {
-                health = (Math.ceil(((this.getRealPower() - 1.0F) * ConfigHolder.SERVER.hrHPMult.get().floatValue() ) / 20) * 20) + ConfigHolder.SERVER.hrHPMin.get();
+                health = (Math.ceil(((this.getRealPower() - 1.0F) * ConfigHolder.SERVER.phrHPMult.get().floatValue() ) / 20) * 20) + ConfigHolder.SERVER.phrHPMin.get();
             }
             if (this.owner.getMaxHealth() < health && EntityUtil.applyModifier(this.owner, Attributes.MAX_HEALTH, MAX_HEALTH_UUID, "Max health", health, AttributeModifier.Operation.ADDITION)) {
                 this.owner.setHealth(this.owner.getMaxHealth());
@@ -591,9 +585,22 @@ public class SorcererData implements ISorcererData {
                 player.bob += (f - player.bob) * 0.4F;
             }
 
-        } else {
-            double health = (Math.ceil(((this.getRealPower() - 1.0F) * ConfigHolder.SERVER.npcHPMult.get().floatValue()) / 20) * 20) +  ConfigHolder.SERVER.npcHPMin.get();
-            
+        }
+        else if (this.traits.contains(Trait.HEAVENLY_RESTRICTION_CE)) {
+            if (this.owner.getHealth() > ConfigHolder.SERVER.cehrHP.get()){
+                this.owner.setHealth(ConfigHolder.SERVER.cehrHP.get());
+            }
+            double movement = 1 - this.getRealPower() * 0.05D;
+            movement *= 0.1;
+            EntityUtil.applyModifier(this.owner, Attributes.MAX_HEALTH, MAX_HEALTH_UUID, "Max health", -10, AttributeModifier.Operation.ADDITION);
+            EntityUtil.applyModifier(this.owner, Attributes.ATTACK_SPEED, ATTACK_SPEED_UUID, "Attack speed", 0.5F, AttributeModifier.Operation.MULTIPLY_TOTAL);
+            EntityUtil.applyModifier(this.owner, Attributes.ATTACK_DAMAGE, ATTACK_DAMAGE_UUID, "Attack damage", 0.5F, AttributeModifier.Operation.MULTIPLY_TOTAL);
+            EntityUtil.applyModifier(this.owner, Attributes.MOVEMENT_SPEED, MOVEMENT_SPEED_UUID, "Movement speed", -movement, AttributeModifier.Operation.ADDITION);
+            EntityUtil.applyModifier(this.owner, ForgeMod.STEP_HEIGHT_ADDITION.get(), STEP_HEIGHT_UUID, "Step height addition", -5.0F, AttributeModifier.Operation.ADDITION);
+            EntityUtil.applyModifier(this.owner, Attributes.ARMOR, ARMOR_UUID, "Armor", -20F, AttributeModifier.Operation.ADDITION);
+            EntityUtil.applyModifier(this.owner, Attributes.ARMOR_TOUGHNESS, ARMOR_TOUGHNESS_UUID, "Armor toughness", 0.4F, AttributeModifier.Operation.MULTIPLY_TOTAL);
+        }
+        else {
             double damage = this.getRealPower() * 1.0D;
             if (this.owner instanceof Player player) {
                 health = (Math.ceil(((this.getRealPower() - 1.0F) * ConfigHolder.SERVER.playerHPMult.get().floatValue()) / 20) * 20) +  ConfigHolder.SERVER.playerHPMin.get();
@@ -648,7 +655,10 @@ public class SorcererData implements ISorcererData {
     public float getMaximumOutput() {
         float output = 1.0F;
 
-        if (this.toggled.contains(JJKAbilities.MYTHICAL_BEAST_AMBER.get() )) {
+        if (this.traits.contains(Trait.HEAVENLY_RESTRICTION_CE )){
+            output = ConfigHolder.SERVER.cehrOutputMax.get().floatValue() / 100F;
+        }
+        else if (this.toggled.contains(JJKAbilities.MYTHICAL_BEAST_AMBER.get() )) {
             output = 1.5F;
         }
         else if (this.isInZone())  {
@@ -663,7 +673,7 @@ public class SorcererData implements ISorcererData {
             stacks.add(stack.getItem());
             stacks.addAll(CuriosUtil.findSlots(owner, owner.getMainArm() == HumanoidArm.RIGHT ? "right_hand" : "left_hand")
                     .stream().map(ItemStack::getItem).toList());
-            if (stacks.contains(JJKItems.HITEN_STAFF.get()) && !this.traits.contains(Trait.HEAVENLY_RESTRICTION)) {
+            if (stacks.contains(JJKItems.HITEN_STAFF.get()) && !this.traits.contains(Trait.HEAVENLY_RESTRICTION_PHYSICAL)) {
                 output = 1.1F;
             }
         }
@@ -1337,7 +1347,7 @@ public class SorcererData implements ISorcererData {
 
     @Override
     public float getEnergy() {
-        if (this.traits.contains(Trait.HEAVENLY_RESTRICTION)) {
+        if (this.traits.contains(Trait.HEAVENLY_RESTRICTION_PHYSICAL)) {
             return 0.0F;
         }
         return this.energy;
@@ -1350,7 +1360,7 @@ public class SorcererData implements ISorcererData {
     }
 
    @Override
-public float getMaxEnergy() {
+    public float getMaxEnergy() {
     long time = this.owner.level().getLevelData().getDayTime();
     boolean night = time >= 13000 && time < 24000;
 
@@ -1368,6 +1378,7 @@ public float getMaxEnergy() {
     
     float finalEnergy = Math.min(maxCapacity * timeMultiplier, (baseCapacity * timeMultiplier + this.extraEnergy) );
     finalEnergy += this.additionalEnergy;
+    finalEnergy = this.hasTrait(Trait.HEAVENLY_RESTRICTION_CE) ? Float.MAX_VALUE : finalEnergy;
 
     return finalEnergy;
 }
@@ -1725,7 +1736,8 @@ public float getMaxEnergy() {
     public void wipe(ServerPlayer owner) {
         this.setExperience(0.0F);
         PlayerUtil.removeAdvancement(owner, "six_eyes");
-        PlayerUtil.removeAdvancement(owner, "heavenly_restriction");
+        PlayerUtil.removeAdvancement(owner, "heavenly_restriction_physical");
+        PlayerUtil.removeAdvancement(owner, "heavenly_restriction_ce");
         PlayerUtil.removeAdvancement(owner, "vessel");
         PlayerUtil.removeAdvancement(owner, "perfect_body");
         this.resetCopy();
@@ -1997,10 +2009,13 @@ public float getMaxEnergy() {
                 traits.addAll(cap.getTraits());
             }
         }
-
-        if ( (isUniqueTraitAllowed(Trait.HEAVENLY_RESTRICTION)  || !traits.contains(Trait.HEAVENLY_RESTRICTION)) &&
+        if ((isUniqueTraitAllowed(Trait.HEAVENLY_RESTRICTION_CE)  || (!traits.contains(Trait.HEAVENLY_RESTRICTION_PHYSICAL) && !traits.contains(Trait.HEAVENLY_RESTRICTION_CE))) &&
+                HelperMethods.RANDOM.nextInt(ConfigHolder.SERVER.heavenlyRestrictionRarity.get()) == 0) {
+            this.addTrait(Trait.HEAVENLY_RESTRICTION_CE);
+        }
+        else if ((isUniqueTraitAllowed(Trait.HEAVENLY_RESTRICTION_PHYSICAL)  || (!traits.contains(Trait.HEAVENLY_RESTRICTION_PHYSICAL) && !traits.contains(Trait.HEAVENLY_RESTRICTION_CE))) &&
             HelperMethods.RANDOM.nextInt(ConfigHolder.SERVER.heavenlyRestrictionRarity.get()) == 0) {
-            this.addTrait(Trait.HEAVENLY_RESTRICTION);
+            this.addTrait(Trait.HEAVENLY_RESTRICTION_PHYSICAL);
         } else {
             this.type = HelperMethods.RANDOM.nextInt(ConfigHolder.SERVER.curseRarity.get()) == 0 ? JujutsuType.CURSE : JujutsuType.SORCERER;
            
@@ -2121,7 +2136,8 @@ public float getMaxEnergy() {
                 owner.sendSystemMessage(Component.translatable(String.format("chat.%s.sorcerer", JujutsuKaisen.MOD_ID)));
             }
         }
-        this.energy = this.getMaxEnergy();
+
+        this.energy = this.traits.contains(Trait.HEAVENLY_RESTRICTION_CE) ? 0.0F : this.getMaxEnergy();
         if (ConfigHolder.SERVER.livesconfig.get() > 0) {
             owner.sendSystemMessage(Component.translatable(String.format("chat.%s.lives", JujutsuKaisen.MOD_ID), this.lives ));
         }

--- a/src/main/java/radon/jujutsu_kaisen/capability/data/sorcerer/SorcererDataHandler.java
+++ b/src/main/java/radon/jujutsu_kaisen/capability/data/sorcerer/SorcererDataHandler.java
@@ -41,7 +41,11 @@ public class SorcererDataHandler {
         newCap.deserializeNBT(oldCap.serializeNBT());
 
         if (event.isWasDeath()) {
-            newCap.setEnergy(newCap.getMaxEnergy());
+            if (oldCap.hasTrait(Trait.HEAVENLY_RESTRICTION_CE)){
+                newCap.setEnergy(oldCap.getEnergy());
+            }else{
+                newCap.setEnergy(newCap.getMaxEnergy());
+            }
             newCap.resetCooldowns();
             newCap.resetBurnout();
             newCap.resetDisable();

--- a/src/main/java/radon/jujutsu_kaisen/capability/data/sorcerer/Trait.java
+++ b/src/main/java/radon/jujutsu_kaisen/capability/data/sorcerer/Trait.java
@@ -1,14 +1,12 @@
 package radon.jujutsu_kaisen.capability.data.sorcerer;
 
 import net.minecraft.network.chat.Component;
-import org.jetbrains.annotations.Nullable;
 import radon.jujutsu_kaisen.JujutsuKaisen;
-import radon.jujutsu_kaisen.ability.JJKAbilities;
-import radon.jujutsu_kaisen.ability.base.Ability;
 
 public enum Trait {
     SIX_EYES,
-    HEAVENLY_RESTRICTION,
+    HEAVENLY_RESTRICTION_PHYSICAL,
+    HEAVENLY_RESTRICTION_CE,
     VESSEL,
     RCT_OUTPUT,
     INCARNATED,

--- a/src/main/java/radon/jujutsu_kaisen/client/JJKClientEventHandler.java
+++ b/src/main/java/radon/jujutsu_kaisen/client/JJKClientEventHandler.java
@@ -19,7 +19,6 @@ import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.HumanoidArm;
 import net.minecraft.world.entity.LivingEntity;
-import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.GrassColor;
 import net.minecraft.world.phys.AABB;
@@ -33,18 +32,14 @@ import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import radon.jujutsu_kaisen.ability.base.Ability;
 import radon.jujutsu_kaisen.ability.base.ITransformation;
-import radon.jujutsu_kaisen.client.gui.MeleeMenuType;
-import radon.jujutsu_kaisen.client.gui.screen.*;
 import radon.jujutsu_kaisen.client.render.entity.idle_transfiguration.PolymorphicSoulIsomerRenderer;
 import radon.jujutsu_kaisen.client.render.entity.idle_transfiguration.TransfiguredSoulLargeRenderer;
 import radon.jujutsu_kaisen.client.render.entity.idle_transfiguration.TransfiguredSoulNormalRenderer;
 import radon.jujutsu_kaisen.client.render.entity.idle_transfiguration.TransfiguredSoulSmallRenderer;
-import radon.jujutsu_kaisen.config.ConfigHolder;
 import radon.jujutsu_kaisen.entity.NyoiStaffEntity;
 import radon.jujutsu_kaisen.mixin.client.IItemInHandRendererAccessor;
 import radon.jujutsu_kaisen.mixin.client.IPlayerModelAccessor;
 import radon.jujutsu_kaisen.network.packet.c2s.*;
-import radon.jujutsu_kaisen.util.CuriosUtil;
 import radon.jujutsu_kaisen.JujutsuKaisen;
 import radon.jujutsu_kaisen.ability.JJKAbilities;
 import radon.jujutsu_kaisen.block.JJKBlocks;
@@ -74,14 +69,11 @@ import radon.jujutsu_kaisen.client.visual.ClientVisualHandler;
 import radon.jujutsu_kaisen.effect.JJKEffects;
 import radon.jujutsu_kaisen.entity.JJKEntities;
 import radon.jujutsu_kaisen.entity.curse.KuchisakeOnnaEntity;
-import radon.jujutsu_kaisen.item.JJKItems;
 import radon.jujutsu_kaisen.network.PacketHandler;
 import radon.jujutsu_kaisen.tags.JJKItemTags;
 import radon.jujutsu_kaisen.util.RotationUtil;
 import software.bernie.geckolib.animatable.GeoItem;
 import software.bernie.geckolib.renderer.GeoArmorRenderer;
-
-import java.io.IOException;
 
 public class JJKClientEventHandler {
     @Mod.EventBusSubscriber(modid = JujutsuKaisen.MOD_ID, bus = Mod.EventBusSubscriber.Bus.FORGE, value = Dist.CLIENT)
@@ -250,10 +242,10 @@ public class JJKClientEventHandler {
 
             if (data == null) return;
          
-            if (data.traits.contains(Trait.HEAVENLY_RESTRICTION)) {
+            if (data.traits.contains(Trait.HEAVENLY_RESTRICTION_PHYSICAL)) {
                 if (!(Minecraft.getInstance().getCameraEntity() instanceof LivingEntity viewer)) return;
 
-                if (JJKAbilities.hasTrait(viewer, Trait.HEAVENLY_RESTRICTION)) return;
+                if (JJKAbilities.hasTrait(viewer, Trait.HEAVENLY_RESTRICTION_PHYSICAL)) return;
 
                 if (target != viewer) {
                     Vec3 look = RotationUtil.getTargetAdjustedLookAngle(viewer);

--- a/src/main/java/radon/jujutsu_kaisen/client/gui/overlay/CursedEnergyOverlay.java
+++ b/src/main/java/radon/jujutsu_kaisen/client/gui/overlay/CursedEnergyOverlay.java
@@ -15,7 +15,9 @@ import radon.jujutsu_kaisen.ability.base.Ability;
 import radon.jujutsu_kaisen.capability.data.sorcerer.ISorcererData;
 import radon.jujutsu_kaisen.capability.data.sorcerer.SorcererDataHandler;
 import radon.jujutsu_kaisen.capability.data.sorcerer.CursedTechnique;
+import radon.jujutsu_kaisen.capability.data.sorcerer.Trait;
 import radon.jujutsu_kaisen.client.particle.ParticleColors;
+import radon.jujutsu_kaisen.config.ConfigHolder;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -63,7 +65,7 @@ public class CursedEnergyOverlay {
 
             graphics.blit(TEXTURE, 20, aboveY, 0, 0, 93, 10, 93, 18);
 
-            float energyWidth = (cap.getEnergy() / cap.getMaxEnergy()) * 94.0F;
+            float energyWidth = cap.hasTrait(Trait.HEAVENLY_RESTRICTION_CE) ? 94.0F : (cap.getEnergy() / cap.getMaxEnergy()) * 94.0F;
             graphics.blit(TEXTURE, 20, aboveY + 1, 0, 10, (int) energyWidth, 8, 93, 18);
 
             RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
@@ -73,8 +75,13 @@ public class CursedEnergyOverlay {
         graphics.pose().scale(SCALE, SCALE, SCALE);
 
         if (cap.getEnergy() > 0.0F) {
-            graphics.drawString(gui.getFont(), String.format("%.1f / %.1f", cap.getEnergy(), cap.getMaxEnergy()),
-                    Math.round(23 * (1.0F / SCALE)), Math.round((aboveY + 3.0F) * (1.0F / SCALE)), 16777215);
+            if (cap.hasTrait(Trait.HEAVENLY_RESTRICTION_CE)){
+                graphics.drawString(gui.getFont(), String.format(cap.getEnergy() > 1000000 ? "∞ / ∞" : "%.1f / ∞", cap.getEnergy()),
+                        Math.round(23 * (1.0F / SCALE)), Math.round((aboveY + 3.0F) * (1.0F / SCALE)), 16777215);
+            }else {
+                graphics.drawString(gui.getFont(), String.format("%.1f / %.1f", cap.getEnergy(), cap.getMaxEnergy()),
+                        Math.round(23 * (1.0F / SCALE)), Math.round((aboveY + 3.0F) * (1.0F / SCALE)), 16777215);
+            }
             aboveY += 4;
         }
 

--- a/src/main/java/radon/jujutsu_kaisen/client/gui/overlay/SixEyesOverlay.java
+++ b/src/main/java/radon/jujutsu_kaisen/client/gui/overlay/SixEyesOverlay.java
@@ -33,10 +33,14 @@ public class SixEyesOverlay {
 
         if (data == null) return;
 
-        if (data.traits.contains(Trait.HEAVENLY_RESTRICTION)) return;
+        if (data.traits.contains(Trait.HEAVENLY_RESTRICTION_PHYSICAL)) return;
 
         List<Component> lines = new ArrayList<>();
 
+        if (data.traits.contains(Trait.HEAVENLY_RESTRICTION_CE)){
+            Component overflowingCEText = Component.translatable(String.format("gui.%s.six_eyes_overlay.heavenly_restriction_ce", JujutsuKaisen.MOD_ID));
+            lines.add(overflowingCEText);
+        }
         if (data.technique != null) {
             Component techniqueText = Component.translatable(String.format("gui.%s.six_eyes_overlay.cursed_technique", JujutsuKaisen.MOD_ID),
                     data.technique.getName());

--- a/src/main/java/radon/jujutsu_kaisen/client/gui/screen/tab/StatsTab.java
+++ b/src/main/java/radon/jujutsu_kaisen/client/gui/screen/tab/StatsTab.java
@@ -126,7 +126,7 @@ public class StatsTab extends JJKTab {
             component.append(Component.translatable(String.format("gui.%s.stats.cursed_technique", JujutsuKaisen.MOD_ID), Component.translatable(String.format("gui.%s.stats.cursed_technique.none", JujutsuKaisen.MOD_ID )) ));
             component.append("\n");
         }
-        if (!cap.hasTrait(Trait.HEAVENLY_RESTRICTION)) {
+        if (!cap.hasTrait(Trait.HEAVENLY_RESTRICTION_PHYSICAL)) {
             component.append(Component.translatable(String.format("gui.%s.stats.cursed_energy_nature", JujutsuKaisen.MOD_ID), cap.getNature().getName()));
             component.append("\n");
         }

--- a/src/main/java/radon/jujutsu_kaisen/config/ServerConfig.java
+++ b/src/main/java/radon/jujutsu_kaisen/config/ServerConfig.java
@@ -5,12 +5,9 @@ import radon.jujutsu_kaisen.capability.data.sorcerer.CursedTechnique;
 import radon.jujutsu_kaisen.capability.data.sorcerer.JujutsuType;
 import radon.jujutsu_kaisen.capability.data.sorcerer.Trait;
 
-import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 public class ServerConfig {
@@ -96,8 +93,11 @@ public class ServerConfig {
     public final ForgeConfigSpec.DoubleValue playerMaxSpeed;
     public final ForgeConfigSpec.DoubleValue HRMaxSpeed;
     public final ForgeConfigSpec.IntValue npcHPMin;
-    public final ForgeConfigSpec.DoubleValue hrHPMult;
-    public final ForgeConfigSpec.IntValue hrHPMin;
+    public final ForgeConfigSpec.DoubleValue phrHPMult;
+    public final ForgeConfigSpec.IntValue phrHPMin;
+    public final ForgeConfigSpec.IntValue cehrHP;
+    public final ForgeConfigSpec.DoubleValue cehrCEMult;
+    public final ForgeConfigSpec.IntValue cehrOutputMax;
     public final ForgeConfigSpec.DoubleValue playerM1Mult;
     public final ForgeConfigSpec.DoubleValue limitlessNoSixEyesMult;
     public final ForgeConfigSpec.DoubleValue sixEyesMult;
@@ -287,7 +287,7 @@ public class ServerConfig {
                 .define("MBAReroll", false);
         this.wcsCutAnything = builder.comment("Whether World Cutting Slash truly cuts the world (destroys indestructible blocks).")
                 .define("wcsCutAnything", true);
-        this.hrRequiredForISOH = builder.comment("Whether Heavenly Restriction is required to use the Inverted Spear of Heaven")
+        this.hrRequiredForISOH = builder.comment("Whether Physical Heavenly Restriction is required to use the Inverted Spear of Heaven")
                 .define("hrRequiredForISOH", false);
         this.playerRequiredForRCT = builder.comment("Whether Players must kill you in order for you to unlock RCT")
                 .define("playerRequiredForRCT", false);
@@ -311,7 +311,7 @@ public class ServerConfig {
                 .defineInRange("sorcererDefenseMult", 1.0F, 0.0F, 9999.0F);
         this.jujutsuDefenseMult = builder.comment("The multiplier to standard players' defense")
                 .defineInRange("jujutsuDefenseMult", 1.0F, 0.0F, 9999.0F);
-        this.hrDefenseMult = builder.comment("The multiplier to Heavenly Restriction players's defense (already higher outside of config)")
+        this.hrDefenseMult = builder.comment("The multiplier to Physical Heavenly Restriction players's defense (already higher outside of config)")
                 .defineInRange("hrDefenseMult", 1.0F, 0.0F, 9999.0F);
         this.playerDamageMult = builder.comment("The multiplier to all player attacks (includes summons of all kinds)")
                 .defineInRange("playerDamageMult", 1.0F, 0.0F, 9999.0F);
@@ -329,14 +329,20 @@ public class ServerConfig {
                 .defineInRange("playerCEArmorMax", 20.0F, 0.0F, 9999.0F);
         this.playerMaxSpeed = builder.comment("The maximum boost to player movement speed, scales to 0.32 at 20k exp by default (DOES NOT CAP PROJECTION OR SCALE SPEED HIGHER).")
                 .defineInRange("playerMaxSpeed", 0.32F, 0.0F, 9999.0F);
-        this.HRMaxSpeed = builder.comment("The maximum boost to Heavenly Restriction movement speed, scales to 0.8 at 20k by default (DOES NOT SCALE SPEED HIGHER)")
+        this.HRMaxSpeed = builder.comment("The maximum boost to Physical Heavenly Restriction movement speed, scales to 0.8 at 20k by default (DOES NOT SCALE SPEED HIGHER)")
                 .defineInRange("HRMaxSpeed", 0.8F, 0.0F, 9999.0F);
         this.playerHPMin = builder.comment("The minimum health of a player.")
                 .defineInRange("playerHPMin", 40, 1, 9999);
-        this.hrHPMult = builder.comment("The multiplier to a heavenly restriction player's HP (scales by bars, so will move by 20 hp increments)")
-                .defineInRange("hrHPMult", 15.0F, 0.0F, 9999.0F);
-        this.hrHPMin = builder.comment("The minimum health of a Heavenly Restriction player.")
-                .defineInRange("hrHPMin", 40, 1, 9999);
+        this.phrHPMult = builder.comment("The multiplier to a Physical Heavenly Restriction player's HP (scales by bars, so will move by 20 hp increments)")
+                .defineInRange("phrHPMult", 15.0F, 0.0F, 9999.0F);
+        this.phrHPMin = builder.comment("The minimum health of a Physical Heavenly Restriction player.")
+                .defineInRange("phrHPMin", 40, 1, 9999);
+        this.cehrHP = builder.comment("The health value of a CE Heavenly Restriction player.")
+                .defineInRange("cehrHPMin", 10, 1, 9999);
+        this.cehrCEMult = builder.comment("The CE regeneration multiplier applied to a CE Heavenly Restriction player.")
+                .defineInRange("cehrCEMult", 2.0F, 1.0F, 9999.0F);
+        this.cehrOutputMax = builder.comment("The maximum output of CE for a CE Heavenly Restriction player.")
+                .defineInRange("cehrOutputMax", 500, 100, 9999);
         this.npcHPMin = builder.comment("The minimum health of the mod's NPCs.")
                 .defineInRange("npcHPMin", 40, 1, 9999);
         this.playerM1Mult = builder.comment("The multiplier to player M1 Hit Damage")

--- a/src/main/java/radon/jujutsu_kaisen/entity/ClosedDomainExpansionEntity.java
+++ b/src/main/java/radon/jujutsu_kaisen/entity/ClosedDomainExpansionEntity.java
@@ -11,7 +11,6 @@ import net.minecraft.network.syncher.EntityDataSerializers;
 import net.minecraft.network.syncher.SynchedEntityData;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.util.Mth;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.entity.*;
@@ -27,7 +26,6 @@ import radon.jujutsu_kaisen.VeilHandler;
 import radon.jujutsu_kaisen.ability.JJKAbilities;
 import radon.jujutsu_kaisen.ability.base.DomainExpansion;
 import radon.jujutsu_kaisen.block.JJKBlocks;
-import radon.jujutsu_kaisen.block.domain.DomainBlock;
 import radon.jujutsu_kaisen.block.entity.DomainBlockEntity;
 import radon.jujutsu_kaisen.block.entity.VeilBlockEntity;
 import radon.jujutsu_kaisen.block.entity.VeilRodBlockEntity;
@@ -412,7 +410,7 @@ public class ClosedDomainExpansionEntity extends DomainExpansionEntity {
 
     private void doSureHitEffect(@NotNull LivingEntity owner) {
         for (LivingEntity entity : this.getAffected()) {
-            if (JJKAbilities.hasTrait(entity, Trait.HEAVENLY_RESTRICTION)) {
+            if (JJKAbilities.hasTrait(entity, Trait.HEAVENLY_RESTRICTION_PHYSICAL)) {
                 this.ability.onHitBlock(this, owner, entity.blockPosition());
             } else {
                 this.ability.onHitEntity(this, owner, entity, false);

--- a/src/main/java/radon/jujutsu_kaisen/entity/OpenDomainExpansionEntity.java
+++ b/src/main/java/radon/jujutsu_kaisen/entity/OpenDomainExpansionEntity.java
@@ -10,7 +10,6 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.*;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
 import org.jetbrains.annotations.NotNull;
@@ -106,7 +105,7 @@ public abstract class OpenDomainExpansionEntity extends DomainExpansionEntity {
 
     protected void doSureHitEffect(@NotNull LivingEntity owner) {
         for (LivingEntity entity : this.getAffected()) {
-            if (JJKAbilities.hasTrait(entity, Trait.HEAVENLY_RESTRICTION)) {
+            if (JJKAbilities.hasTrait(entity, Trait.HEAVENLY_RESTRICTION_PHYSICAL)) {
                 this.ability.onHitBlock(this, owner, entity.blockPosition());
             } else {
                 this.ability.onHitEntity(this, owner, entity, false);

--- a/src/main/java/radon/jujutsu_kaisen/entity/ai/goal/NearestAttackableHumanGoal.java
+++ b/src/main/java/radon/jujutsu_kaisen/entity/ai/goal/NearestAttackableHumanGoal.java
@@ -62,7 +62,7 @@ public class NearestAttackableHumanGoal extends TargetGoal {
             if (!(entity instanceof TamableAnimal tamable && entity instanceof ISorcerer && tamable.isTame())) {
                 if (!entity.getCapability(SorcererDataHandler.INSTANCE).isPresent()) return false;
                 ISorcererData cap = entity.getCapability(SorcererDataHandler.INSTANCE).resolve().orElseThrow();
-                return cap.hasTrait(Trait.HEAVENLY_RESTRICTION);
+                return cap.hasTrait(Trait.HEAVENLY_RESTRICTION_PHYSICAL);
             }
             return false;
         }), this.targetConditions, this.mob, this.mob.getX(), this.mob.getEyeY(), this.mob.getZ());

--- a/src/main/java/radon/jujutsu_kaisen/entity/projectile/ThrownChainProjectile.java
+++ b/src/main/java/radon/jujutsu_kaisen/entity/projectile/ThrownChainProjectile.java
@@ -147,8 +147,10 @@ public class ThrownChainProjectile extends AbstractArrow {
             //float speed = this.getDeltaMovement().lengthSqr();
             ISorcererData cap = owner.getCapability(SorcererDataHandler.INSTANCE).resolve().orElseThrow();
             float DAMAGE = 8.5F*cap.getRealPower();
-            if (cap.hasTrait(Trait.HEAVENLY_RESTRICTION)) {
+            if (cap.hasTrait(Trait.HEAVENLY_RESTRICTION_PHYSICAL)) {
                 DAMAGE*=1.3;
+            } else if (cap.hasTrait(Trait.HEAVENLY_RESTRICTION_CE)) {
+                DAMAGE*=0.8;
             }
 
             SwordItem sword = (SwordItem) this.getStack().getItem();
@@ -182,10 +184,12 @@ public class ThrownChainProjectile extends AbstractArrow {
             return;
         }
         ISorcererData cap = owner.getCapability(SorcererDataHandler.INSTANCE).resolve().orElseThrow();
-        if (cap.hasTrait(Trait.HEAVENLY_RESTRICTION)) {
+        if (cap.hasTrait(Trait.HEAVENLY_RESTRICTION_PHYSICAL)) {
             speedMult = 10.0F;
+        } else if (cap.hasTrait(Trait.HEAVENLY_RESTRICTION_CE)) {
+            speedMult = 2.5F;
         }
-        
+
 
         if (!this.level().isClientSide && (owner == null || owner.isRemoved() || !owner.isAlive() || this.inGroundTime > DURATION)) {
             this.discard();

--- a/src/main/java/radon/jujutsu_kaisen/entity/sorcerer/MakiZeninEntity.java
+++ b/src/main/java/radon/jujutsu_kaisen/entity/sorcerer/MakiZeninEntity.java
@@ -60,7 +60,7 @@ public class MakiZeninEntity extends SorcererEntity {
 
     @Override
     public @NotNull List<Trait> getTraits() {
-        return List.of(Trait.HEAVENLY_RESTRICTION);
+        return List.of(Trait.HEAVENLY_RESTRICTION_PHYSICAL);
     }
 
     @Override

--- a/src/main/java/radon/jujutsu_kaisen/entity/sorcerer/TojiFushiguroEntity.java
+++ b/src/main/java/radon/jujutsu_kaisen/entity/sorcerer/TojiFushiguroEntity.java
@@ -188,7 +188,7 @@ public class TojiFushiguroEntity extends SorcererEntity {
 
     @Override
     public @NotNull List<Trait> getTraits() {
-        return List.of(Trait.HEAVENLY_RESTRICTION);
+        return List.of(Trait.HEAVENLY_RESTRICTION_PHYSICAL);
     }
 
     @Override

--- a/src/main/java/radon/jujutsu_kaisen/event/JJKEventHandler.java
+++ b/src/main/java/radon/jujutsu_kaisen/event/JJKEventHandler.java
@@ -1,6 +1,5 @@
 package radon.jujutsu_kaisen.event;
 
-import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.particles.BlockParticleOption;
 import net.minecraft.core.particles.ParticleTypes;
@@ -9,7 +8,6 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.tags.DamageTypeTags;
 import net.minecraft.world.InteractionHand;
-import net.minecraft.world.damagesource.CombatRules;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.effect.MobEffects;
@@ -32,7 +30,6 @@ import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.event.level.BlockEvent;
 import net.minecraftforge.event.level.ExplosionEvent;
 import net.minecraftforge.event.level.SleepFinishedTimeEvent;
-import net.minecraftforge.event.level.NoteBlockEvent.Play;
 import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
@@ -40,11 +37,8 @@ import radon.jujutsu_kaisen.JujutsuKaisen;
 import radon.jujutsu_kaisen.VeilHandler;
 import radon.jujutsu_kaisen.ability.*;
 import radon.jujutsu_kaisen.ability.base.Ability;
-import radon.jujutsu_kaisen.ability.base.Summon;
-import radon.jujutsu_kaisen.ability.misc.Slam;
 import radon.jujutsu_kaisen.block.VeilBlock;
 import radon.jujutsu_kaisen.block.VeilRodBlock;
-import radon.jujutsu_kaisen.block.entity.VeilRodBlockEntity;
 import radon.jujutsu_kaisen.capability.data.sorcerer.ISorcererData;
 import radon.jujutsu_kaisen.capability.data.sorcerer.SorcererDataHandler;
 import radon.jujutsu_kaisen.capability.data.sorcerer.CursedTechnique;
@@ -68,7 +62,6 @@ import radon.jujutsu_kaisen.network.PacketHandler;
 import radon.jujutsu_kaisen.network.packet.s2c.SyncSorcererDataS2CPacket;
 import radon.jujutsu_kaisen.util.*;
 import virtuoel.pehkui.api.ScaleData;
-import virtuoel.pehkui.api.ScaleType;
 import virtuoel.pehkui.api.ScaleTypes;
 
 import java.util.ArrayList;
@@ -164,8 +157,9 @@ public class JJKEventHandler {
                     if (!player.getCapability(SorcererDataHandler.INSTANCE).isPresent()) continue;
 
                     ISorcererData cap = player.getCapability(SorcererDataHandler.INSTANCE).resolve().orElseThrow();
-                    cap.setEnergy(cap.getMaxEnergy());
-
+                    if (!cap.hasTrait(Trait.HEAVENLY_RESTRICTION_CE)){
+                        cap.setEnergy(cap.getMaxEnergy());
+                    }
                     PacketHandler.sendToClient(new SyncSorcererDataS2CPacket(cap.serializeNBT()), player);
                 }
             }
@@ -205,7 +199,11 @@ public class JJKEventHandler {
             newCap.deserializeNBT(oldCap.serializeNBT());
 
             if (event.isWasDeath()) {
-                newCap.setEnergy(newCap.getMaxEnergy());
+                if (oldCap.hasTrait(Trait.HEAVENLY_RESTRICTION_CE)){
+                    newCap.setEnergy(oldCap.getEnergy());
+                }else{
+                    newCap.setEnergy(newCap.getMaxEnergy());
+                }
                 newCap.resetCooldowns();
                 newCap.resetBurnout();
                 newCap.resetDisable();
@@ -262,7 +260,7 @@ public class JJKEventHandler {
 
             cap.tick(owner);
 
-            if ((cap.hasTrait(Trait.SIX_EYES) && (!owner.getItemBySlot(EquipmentSlot.HEAD).is(JJKItems.BLINDFOLD.get()) && !CuriosUtil.findSlot(owner, "head").is(JJKItems.BLINDFOLD.get()) ) ) || cap.hasTrait(Trait.HEAVENLY_RESTRICTION)) {
+            if ((cap.hasTrait(Trait.SIX_EYES) && (!owner.getItemBySlot(EquipmentSlot.HEAD).is(JJKItems.BLINDFOLD.get()) && !CuriosUtil.findSlot(owner, "head").is(JJKItems.BLINDFOLD.get()) ) ) || cap.hasTrait(Trait.HEAVENLY_RESTRICTION_PHYSICAL)) {
                 owner.addEffect(new MobEffectInstance(MobEffects.NIGHT_VISION, 220, 0, false, false, false));
             }
 
@@ -287,6 +285,18 @@ public class JJKEventHandler {
                         baseScale.markForSync(true);
                     //}
             }
+            else if((cap.hasTrait(Trait.HEAVENLY_RESTRICTION_CE) )) {
+                if (owner instanceof Player) {
+                    if (cap != null) {
+                        float targetScale = 1.0F;
+                        float targetWidth = 0.9F;
+                        ScaleData baseScale = ScaleTypes.BASE.getScaleData(owner);
+                        ScaleData baseWidth = ScaleTypes.WIDTH.getScaleData(owner);
+                        baseScale.setScale(targetScale);
+                        baseWidth.setScale(targetWidth);
+                    }
+                }
+            }
             else if((cap.hasTrait(Trait.CURSED_WOMB) )) {
                 if (owner instanceof Player) {
                 if (cap != null) {
@@ -300,7 +310,7 @@ public class JJKEventHandler {
                 ScaleData baseWidth = ScaleTypes.WIDTH.getScaleData(owner);
                 // float currentScale = baseScale.getScale();
                 // float currentWidth = baseWidth.getScale();
-                baseScale.setScale(targetScale); 
+                baseScale.setScale(targetScale);
                 baseWidth.setScale(targetWidth);
 
                 }
@@ -317,12 +327,12 @@ public class JJKEventHandler {
             }
             
 
-            if (cap.hasTrait(Trait.HEAVENLY_RESTRICTION)) {
+            if (cap.hasTrait(Trait.HEAVENLY_RESTRICTION_PHYSICAL)) {
                 owner.addEffect(new MobEffectInstance(MobEffects.DIG_SPEED, 2, 1, false, false, false));
             }
-
-            owner.addEffect(new MobEffectInstance(MobEffects.JUMP, 2, 2, false, false, false));
-
+            if (!cap.hasTrait(Trait.HEAVENLY_RESTRICTION_CE)) {
+                owner.addEffect(new MobEffectInstance(MobEffects.JUMP, 2, 2, false, false, false));
+            }
             if (owner instanceof Player player) {
                 if ( (cap.getType() == JujutsuType.SORCERER && ConfigHolder.SERVER.sorcererSaturation.get()) || (cap.getType() == JujutsuType.CURSE && ConfigHolder.SERVER.curseSaturation.get()) ) {
                     player.getFoodData().setFoodLevel(20);
@@ -341,8 +351,10 @@ public class JJKEventHandler {
             LivingEntity victim = event.getEntity();
 
             event.getEntity().getCapability(SorcererDataHandler.INSTANCE).ifPresent(cap -> {
-                if (cap.hasTrait(Trait.HEAVENLY_RESTRICTION)) {
+                if (cap.hasTrait(Trait.HEAVENLY_RESTRICTION_PHYSICAL)) {
                     event.setDistance(event.getDistance() * 0.1F);
+                } else if (cap.hasTrait(Trait.HEAVENLY_RESTRICTION_CE)) {
+                    event.setDistance(event.getDistance() * 1.5F);
                 } else {
                     event.setDistance(event.getDistance() * 0.33F);
                 }
@@ -475,7 +487,7 @@ if (JJKAbilities.hasTrait(attacker, Trait.PERFECT_BODY)) {
             if (victim instanceof Player) {
                 armor*=ConfigHolder.SERVER.jujutsuDefenseMult.get().floatValue();
             }
-            if (cap.hasTrait(Trait.HEAVENLY_RESTRICTION)) {
+            if (cap.hasTrait(Trait.HEAVENLY_RESTRICTION_PHYSICAL)) {
 		        armor = SorcererUtil.getDefenseHR(cap.getExperience());
                 if (victim instanceof Player) {
                    armor*=ConfigHolder.SERVER.hrDefenseMult.get().floatValue();

--- a/src/main/java/radon/jujutsu_kaisen/event/RCTEventHandler.java
+++ b/src/main/java/radon/jujutsu_kaisen/event/RCTEventHandler.java
@@ -44,9 +44,9 @@ public class RCTEventHandler {
             if (!victim.getCapability(SorcererDataHandler.INSTANCE).isPresent()) return;
             ISorcererData cap = victim.getCapability(SorcererDataHandler.INSTANCE).resolve().orElseThrow();
 
-            if ((cap.isUnlocked(JJKAbilities.RCT1.get()) && cap.getType() == JujutsuType.SORCERER) || (cap.hasTrait(Trait.CURSED_WOMB) && cap.checkWombAwakened() == true  ) ) return;
+            if ((cap.isUnlocked(JJKAbilities.RCT1.get()) && cap.getType() == JujutsuType.SORCERER) || (cap.hasTrait(Trait.CURSED_WOMB) && cap.checkWombAwakened()) ) return;
             if (victim instanceof TamableAnimal tamable && tamable.isTame()) return;
-            if (cap.hasTrait(Trait.HEAVENLY_RESTRICTION)) return;
+            if (cap.hasTrait(Trait.HEAVENLY_RESTRICTION_PHYSICAL)) return;
             if (cap.getType() != JujutsuType.SORCERER && !cap.hasTrait(Trait.CURSED_WOMB) ) return;
             if (SorcererUtil.getGrade(cap.getExperience()).ordinal() < SorcererGrade.SEMI_GRADE_2.ordinal()) return;
 

--- a/src/main/java/radon/jujutsu_kaisen/event/WeaponEventHandler.java
+++ b/src/main/java/radon/jujutsu_kaisen/event/WeaponEventHandler.java
@@ -20,9 +20,6 @@ import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import radon.jujutsu_kaisen.JujutsuKaisen;
 import radon.jujutsu_kaisen.ability.JJKAbilities;
-import radon.jujutsu_kaisen.ability.base.Ability;
-import radon.jujutsu_kaisen.ability.base.Summon;
-import radon.jujutsu_kaisen.ability.base.DomainExpansion;
 import radon.jujutsu_kaisen.capability.data.sorcerer.CursedTechnique;
 import radon.jujutsu_kaisen.capability.data.sorcerer.ISorcererData;
 import radon.jujutsu_kaisen.capability.data.sorcerer.SorcererDataHandler;
@@ -91,7 +88,7 @@ public class WeaponEventHandler {
                     attacker.level().explode(attacker, attacker.damageSources().explosion(attacker, null), null, pos.x, pos.y, pos.z, 1.0F, false, Level.ExplosionInteraction.NONE);
                 }
 
-                if (stacks.contains(JJKItems.INVERTED_SPEAR_OF_HEAVEN.get()) && (!ConfigHolder.SERVER.hrRequiredForISOH.get()  || JJKAbilities.hasTrait(attacker, Trait.HEAVENLY_RESTRICTION) )  ) {
+                if (stacks.contains(JJKItems.INVERTED_SPEAR_OF_HEAVEN.get()) && (!ConfigHolder.SERVER.hrRequiredForISOH.get()  || JJKAbilities.hasTrait(attacker, Trait.HEAVENLY_RESTRICTION_PHYSICAL) )  ) {
                    
                     /* 
                     if (victim.getCapability(SorcererDataHandler.INSTANCE).isPresent()) {
@@ -196,7 +193,7 @@ public class WeaponEventHandler {
                    // source = JJKDamageSources.splitSoulKatanaAttack(victim);
                     //event.setAmount(event.getAmount()*0.9f);
                    // event.setAmount(event.getAmount()*0.196f); //all
-                    if (JJKAbilities.hasTrait(attacker, Trait.HEAVENLY_RESTRICTION) && !source.is(JJKDamageSources.SPLIT_SOUL_KATANA) ) {
+                    if (JJKAbilities.hasTrait(attacker, Trait.HEAVENLY_RESTRICTION_PHYSICAL) && !source.is(JJKDamageSources.SPLIT_SOUL_KATANA) ) {
                         if (victim.hurt(JJKDamageSources.splitSoulKatanaAttack(attacker),event.getAmount() * 1.0f )) {
                             //if (victim.hurt(JJKDamageSources.splitSoulKatanaAttack(attacker),event.getAmount() * 0.05f )) {
                                  event.setAmount(event.getAmount()*0.1f);
@@ -213,7 +210,7 @@ public class WeaponEventHandler {
                 //}
 
                 if (stacks.contains(JJKItems.PLAYFUL_CLOUD.get())) {
-                    if (JJKAbilities.hasTrait(attacker, Trait.HEAVENLY_RESTRICTION)) {
+                    if (JJKAbilities.hasTrait(attacker, Trait.HEAVENLY_RESTRICTION_PHYSICAL)) {
                         event.setAmount(event.getAmount()*1.2f);
                     } else {
                         event.setAmount(event.getAmount()*1.05f);

--- a/src/main/java/radon/jujutsu_kaisen/item/cursed_object/SukunaFingerItem.java
+++ b/src/main/java/radon/jujutsu_kaisen/item/cursed_object/SukunaFingerItem.java
@@ -1,6 +1,5 @@
 package radon.jujutsu_kaisen.item.cursed_object;
 
-import net.minecraft.util.Mth;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResultHolder;
 import net.minecraft.world.effect.MobEffectInstance;
@@ -16,9 +15,7 @@ import radon.jujutsu_kaisen.capability.data.sorcerer.SorcererDataHandler;
 import radon.jujutsu_kaisen.capability.data.sorcerer.JujutsuType;
 import radon.jujutsu_kaisen.capability.data.sorcerer.SorcererGrade;
 import radon.jujutsu_kaisen.capability.data.sorcerer.Trait;
-import radon.jujutsu_kaisen.entity.sorcerer.SukunaEntity;
 import radon.jujutsu_kaisen.item.base.CursedObjectItem;
-import radon.jujutsu_kaisen.util.EntityUtil;
 
 public class SukunaFingerItem extends CursedObjectItem {
     public SukunaFingerItem(Properties pProperties) {
@@ -37,7 +34,7 @@ public class SukunaFingerItem extends CursedObjectItem {
         if (pPlayer.getCapability(SorcererDataHandler.INSTANCE).isPresent()) {
             ISorcererData cap = pPlayer.getCapability(SorcererDataHandler.INSTANCE).resolve().orElseThrow();
 
-            if (cap.hasTrait(Trait.HEAVENLY_RESTRICTION)) {
+            if (cap.hasTrait(Trait.HEAVENLY_RESTRICTION_PHYSICAL)) {
                 return InteractionResultHolder.fail(stack);
             }
 

--- a/src/main/resources/assets/jujutsu_kaisen/lang/en_us.json
+++ b/src/main/resources/assets/jujutsu_kaisen/lang/en_us.json
@@ -19,6 +19,7 @@
 
 
   "gui.jujutsu_kaisen.six_eyes_overlay.cursed_technique": "Cursed Technique: %1$s",
+  "gui.jujutsu_kaisen.six_eyes_overlay.heavenly_restriction_ce": "Overflowing CE",
   "gui.jujutsu_kaisen.six_eyes_overlay.grade": "Grade: %1$s",
 
   "gui.jujutsu_kaisen.stats": "Stats",
@@ -526,7 +527,8 @@
   "cursed_energy_nature.jujutsu_kaisen.divergent": "Divergent",
 
   "trait.jujutsu_kaisen.six_eyes": "Six Eyes",
-  "trait.jujutsu_kaisen.heavenly_restriction": "Heavenly Restriction",
+  "trait.jujutsu_kaisen.heavenly_restriction_physical": "Physical Heavenly Restriction",
+  "trait.jujutsu_kaisen.heavenly_restriction_ce": "CE Heavenly Restriction",
   "trait.jujutsu_kaisen.vessel": "Vessel",
   "trait.jujutsu_kaisen.perfect_body": "Perfect Body",
   "trait.jujutsu_kaisen.rct_output": "RCT Output",
@@ -564,7 +566,8 @@
 
   "chat.jujutsu_kaisen.trait.perfect_body": "You achieved a Perfect Body.",
   "chat.jujutsu_kaisen.trait.incarnated": "You were Incarnated as a Sorcerer.",
-  "chat.jujutsu_kaisen.trait.heavenly_restriction": "Your physically gifted body lacks any Cursed Energy.",
+  "chat.jujutsu_kaisen.trait.heavenly_restriction_physical": "Your physically gifted body lacks any Cursed Energy.",
+  "chat.jujutsu_kaisen.trait.heavenly_restriction_ce": "Your Cursed Energy is immense, but your body is weak",
   "chat.jujutsu_kaisen.trait.rct_output": "You hold a unique way to output your Cursed Energy.",
   "chat.jujutsu_kaisen.trait.vessel": "You were born with the potential to serve as a Vessel.",
   "chat.jujutsu_kaisen.trait.six_eyes": "You were born with the Six Eyes. The balance of the world has shifted.",
@@ -768,8 +771,11 @@
   "advancements.jujutsu_kaisen.black_flash.title": "Black Flash",
   "advancements.jujutsu_kaisen.black_flash.description": "The sparks of Black Flash do not choose whom to bless.",
 
-  "advancements.jujutsu_kaisen.heavenly_restriction.title": "Heavenly Restriction",
-  "advancements.jujutsu_kaisen.heavenly_restriction.description": "You were granted unrivaled physical abilities in exchange for your cursed energy.",
+  "advancements.jujutsu_kaisen.heavenly_restriction_physical.title": "Physical Heavenly Restriction",
+  "advancements.jujutsu_kaisen.heavenly_restriction_physical.description": "You were granted unrivaled physical abilities in exchange for your cursed energy.",
+
+  "advancements.jujutsu_kaisen.heavenly_restriction_ce.title": "CE Heavenly Restriction",
+  "advancements.jujutsu_kaisen.heavenly_restriction_ce.description": "Your cursed energy knows no boundaries in exchange for your vitality",
 
   "advancements.jujutsu_kaisen.vessel.title": "Vessel",
   "advancements.jujutsu_kaisen.vessel.description": "Your body seems to be built for containing other's souls.",

--- a/src/main/resources/assets/jujutsu_kaisen/lang/es_es.json
+++ b/src/main/resources/assets/jujutsu_kaisen/lang/es_es.json
@@ -526,7 +526,7 @@
   "cursed_energy_nature.jujutsu_kaisen.divergent": "Divergente",
 
   "trait.jujutsu_kaisen.six_eyes": "Seis Ojos",
-  "trait.jujutsu_kaisen.heavenly_restriction": "Restricción Celestial",
+  "trait.jujutsu_kaisen.heavenly_restriction_physical": "Restricción Celestial",
   "trait.jujutsu_kaisen.vessel": "Recipiente",
   "trait.jujutsu_kaisen.perfect_body": "Cuerpo Perfecto",
   "trait.jujutsu_kaisen.rct_output": "Técnica Inversa Externa",

--- a/src/main/resources/assets/jujutsu_kaisen/lang/pt_br.json
+++ b/src/main/resources/assets/jujutsu_kaisen/lang/pt_br.json
@@ -526,7 +526,7 @@
   "cursed_energy_nature.jujutsu_kaisen.divergent": "Divergente",
 
   "trait.jujutsu_kaisen.six_eyes": "Seis Olhos",
-  "trait.jujutsu_kaisen.heavenly_restriction": "Restrição Divina",
+  "trait.jujutsu_kaisen.heavenly_restriction_physical": "Restrição Divina",
   "trait.jujutsu_kaisen.vessel": "Receptáculo",
   "trait.jujutsu_kaisen.perfect_body": "Corpo Perfeito",
   "trait.jujutsu_kaisen.rct_output": "Reversão Avançada",
@@ -564,7 +564,7 @@
 
   "chat.jujutsu_kaisen.trait.perfect_body": "Você alcançou o Corpo Perfeito.",
   "chat.jujutsu_kaisen.trait.incarnated": "Você foi Incarnado como um Feiticeiro.",
-  "chat.jujutsu_kaisen.trait.heavenly_restriction": "Seu corpo fisicamente divino não possuí Energia Amaldiçoada.",
+  "chat.jujutsu_kaisen.trait.heavenly_restriction_physical": "Seu corpo fisicamente divino não possuí Energia Amaldiçoada.",
   "chat.jujutsu_kaisen.trait.rct_output": "Você tem uma potência única para sua Energia Amaldiçoada.",
   "chat.jujutsu_kaisen.trait.vessel": "Você nasceu com o potencial de um Receptáculo.",
   "chat.jujutsu_kaisen.trait.six_eyes": "Você nasceu com os Seis Olhos. O equilíbrio do mundo se alterou.",
@@ -768,8 +768,8 @@
   "advancements.jujutsu_kaisen.black_flash.title": "Fulgor Negro",
   "advancements.jujutsu_kaisen.black_flash.description": "As Faíscas Negras não escolhem aqueles que são abençoados.",
 
-  "advancements.jujutsu_kaisen.heavenly_restriction.title": "Restrição Celestial",
-  "advancements.jujutsu_kaisen.heavenly_restriction.description": "Você foi garantido(a) habilidades físicas imparáveis em troca de sua Energia Amaldiçoada.",
+  "advancements.jujutsu_kaisen.heavenly_restriction_physical.title": "Restrição Celestial",
+  "advancements.jujutsu_kaisen.heavenly_restriction_physical.description": "Você foi garantido(a) habilidades físicas imparáveis em troca de sua Energia Amaldiçoada.",
 
   "advancements.jujutsu_kaisen.vessel.title": "Receptáculo",
   "advancements.jujutsu_kaisen.vessel.description": "Seu corpo parece ter sido feito para conter as almas de outros.",

--- a/src/main/resources/assets/jujutsu_kaisen/lang/zh_cn.json
+++ b/src/main/resources/assets/jujutsu_kaisen/lang/zh_cn.json
@@ -526,7 +526,7 @@
   "cursed_energy_nature.jujutsu_kaisen.divergent": "延迟",
 
   "trait.jujutsu_kaisen.six_eyes": "六眼",
-  "trait.jujutsu_kaisen.heavenly_restriction": "天与咒缚",
+  "trait.jujutsu_kaisen.heavenly_restriction_physical": "天与咒缚",
   "trait.jujutsu_kaisen.vessel": "容器",
   "trait.jujutsu_kaisen.perfect_body": "完美身体",
   "trait.jujutsu_kaisen.rct_output": "反转术式输出",
@@ -564,7 +564,7 @@
   
   "chat.jujutsu_kaisen.trait.perfect_body": "你拥有一具完美的身体",
   "chat.jujutsu_kaisen.trait.incarnated": "你作为术士受肉到某人身上",
-  "chat.jujutsu_kaisen.trait.heavenly_restriction": "你天赋异禀的身体没有任何一丝咒力",
+  "chat.jujutsu_kaisen.trait.heavenly_restriction_physical": "你天赋异禀的身体没有任何一丝咒力",
   "chat.jujutsu_kaisen.trait.rct_output": "你能通过独特的方式输出你的咒力",
   "chat.jujutsu_kaisen.trait.vessel": "你有着成为某人容器的独特潜力",
   "chat.jujutsu_kaisen.trait.six_eyes": "你拥有六眼，这使得世界的平衡发生了变化",
@@ -768,8 +768,8 @@
   "advancements.jujutsu_kaisen.black_flash.title": "黑闪",
   "advancements.jujutsu_kaisen.black_flash.description": "黑闪的火花不会选择祝福何人。",
 
-  "advancements.jujutsu_kaisen.heavenly_restriction.title": "天与咒缚",
-  "advancements.jujutsu_kaisen.heavenly_restriction.description": "你以咒力为代价，换来了无与伦比的肉体能力。",
+  "advancements.jujutsu_kaisen.heavenly_restriction_physical.title": "天与咒缚",
+  "advancements.jujutsu_kaisen.heavenly_restriction_physical.description": "你以咒力为代价，换来了无与伦比的肉体能力。",
 
   "advancements.jujutsu_kaisen.vessel.title": "容器",
   "advancements.jujutsu_kaisen.vessel.description": "你的身体似乎天生就是为了容纳他人的灵魂。",

--- a/src/main/resources/data/jujutsu_kaisen/advancements/jujutsu_kaisen/heavenly_restriction_ce.json
+++ b/src/main/resources/data/jujutsu_kaisen/advancements/jujutsu_kaisen/heavenly_restriction_ce.json
@@ -2,13 +2,13 @@
   "parent": "jujutsu_kaisen:jujutsu_kaisen/root",
   "display": {
     "icon": {
-      "item": "minecraft:chain"
+      "item": "minecraft:dead_bush"
     },
     "title": {
-      "translate": "advancements.jujutsu_kaisen.heavenly_restriction.title"
+      "translate": "advancements.jujutsu_kaisen.heavenly_restriction_ce.title"
     },
     "description": {
-      "translate": "advancements.jujutsu_kaisen.heavenly_restriction.description"
+      "translate": "advancements.jujutsu_kaisen.heavenly_restriction_ce.description"
     },
     "frame": "challenge",
     "hidden": false,

--- a/src/main/resources/data/jujutsu_kaisen/advancements/jujutsu_kaisen/heavenly_restriction_physical.json
+++ b/src/main/resources/data/jujutsu_kaisen/advancements/jujutsu_kaisen/heavenly_restriction_physical.json
@@ -1,0 +1,23 @@
+{
+  "parent": "jujutsu_kaisen:jujutsu_kaisen/root",
+  "display": {
+    "icon": {
+      "item": "minecraft:chain"
+    },
+    "title": {
+      "translate": "advancements.jujutsu_kaisen.heavenly_restriction_physical.title"
+    },
+    "description": {
+      "translate": "advancements.jujutsu_kaisen.heavenly_restriction_physical.description"
+    },
+    "frame": "challenge",
+    "hidden": false,
+    "show_toast": true,
+    "announce_to_chat": true
+  },
+  "criteria": {
+    "impossible": {
+      "trigger": "minecraft:impossible"
+    }
+  }
+}


### PR DESCRIPTION
Had to separate original HR translation keys to heavenly_restriction_physical (Physical prowess) and heavenly_restriction_ce (Overflowing CE). Traits are also separated accordingly.
Missing translations for all langs except english.

Shares rarity with physical prowess HR, only one variant of HR possible at a time when generating sorcererdata 
Six eyes show "Overflowing CE" if the target has this HR

Downsides:
- Makes you basically unable to move without using CE flow/high output (movement debuff lowers with XP)
- Take 1.5x fall damage
- Configurable maximum amount of HP that doesn't scale with XP (10 HP by default)
- 2x all the melee move CDs and 0.8x all the melee move damage
- Punch/barrage/slam don't cause stagger
- Significantly reduces slam explosion radius.
- Less force with the Chain of a thousand miles
- Dashes have less range and speed
- No autostep for stairs (Most important debuff)

Upsides:
- Infinite CE storage (float limit)
- Configurable Output increase (500% by default) |Kinda mimics mechamaru using 2+ years worth of CE at once|
- Configurable CE regen speed (2x by default)
